### PR TITLE
Added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Inherit from node v4 docker image
+FROM node:4-wheezy
+
+RUN apt-get update
+RUN apt-get install curl -y
+
+ADD package.json /app/package.json
+RUN cd /app && npm install
+
+EXPOSE 3000
+ENV PORT=3000
+
+WORKDIR /app
+ADD . /app
+
+#CMD ["node", "devServer.js"]
+CMD ["npm", "run", "start"]

--- a/devServer.js
+++ b/devServer.js
@@ -2,7 +2,9 @@ var path = require('path');
 var express = require('express');
 var webpack = require('webpack');
 var config = require('./webpack.config.dev');
-var port = 3000;
+var DEFAULT_PORT = 3000;
+var port = parseInt(process.argv[2]) || process.env.PORT ||  DEFAULT_PORT;
+var hostname = '0.0.0.0';
 var apiRouter = require('./api');
 
 var app = express();
@@ -34,11 +36,11 @@ app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'src/index.html'));
 });
 
-app.listen(port, 'localhost', function(err) {
+app.listen(port, hostname, function(err) {
   if (err) {
     console.log(err);
     return;
   }
 
-  console.log('Building, will serve at http://localhost:' + port);
+  console.log('Building, will serve at http://' + hostname + ':' + port);
 });

--- a/src/models/Instance.js
+++ b/src/models/Instance.js
@@ -1,4 +1,4 @@
-import uuid from '../utils/generators/uuid';
+import uuid from '../utils/generators/UUID';
 
 export default class Instance {
   constructor(forceId = uuid()) {


### PR DESCRIPTION
Added support to run within a Docker container. Minor changes which were:
-- add Dockerfile. The docker container inherits from node v4 container, so that is how node versioning is handled.

-- fix reference to UUID.js  in code to match case of file name. On Ubuntu this was failing due to case sensitivity.

-- change logic for determining the run-time port to be, in order, derived from: command line, environment, default port.
-- change the host name used when setting up the listening port. Changed from 'localhost' to '0.0.0.0'. The latter syntax results in the node server listening on all network addresses, while localhost results in only listening on the loopback address, (and was thus not listening on the other ip address(es) of the machine).