### PR TITLE
fixed CMD launch error in compose file

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -9,9 +9,8 @@ genome-designer:
     - /var/run/docker.sock:/var/run/docker.sock
     - /usr/bin/docker:/usr/bin/docker 
     - /usr/lib64/libdevmapper.so.1.02:/usr/lib/libdevmapper.so.1.02 
-  command: npm run start
 
 
 redis:
   image: redis:3
-  command: redis-server /redis.conf 
+  command: redis-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ genome-designer:
     - /var/run/docker.sock:/var/run/docker.sock
     - /usr/bin/docker:/usr/bin/docker 
     - /usr/lib64/libdevmapper.so.1.02:/usr/lib/libdevmapper.so.1.02 
-  command: npm run start
 
 
 redis:


### PR DESCRIPTION
ENTRYPOINT is retained with docker-compose uses command: 
So if a 'command' command is used in docker-compose and the desired command is  'npm run start' and the Dockerfile ENTRYPOINT contains "npm", then docker-compose command entry should be: 'run start'. Removed the command override in the compose file since it did not differ from the default.
