### PR TITLE
Orchestrator actions

### DIFF
--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -234,7 +234,10 @@ export const blockSetSequence = (blockId, sequence) => {
 
 //todo - work for project.components
 const getParentFromStore = (blockId, store, def) => {
-  return Object.keys(store).find(id => store.blocks[id].components.includes(blockId)) || def;
+  const id = Object.keys(store.blocks).find(id => {
+    return store.blocks[id].components.includes(blockId);
+  });
+  return !!id ? store.blocks[id] : def;
 };
 
 //Non-mutating
@@ -244,8 +247,8 @@ export const blockGetParents = (blockId) => {
     const store = getState();
     let parent = getParentFromStore(blockId, store);
     while (parent) {
-      parents.push(parent);
-      parent = getParentFromStore(parent, store);
+      parents.push(parent.id);
+      parent = getParentFromStore(parent.id, store);
     }
     return parents;
   };
@@ -263,6 +266,6 @@ export const blockGetSiblings = (blockId) => {
 export const blockGetIndex = (blockId) => {
   return (dispatch, getState) => {
     const parent = getParentFromStore(blockId, getState(), {});
-    return Array.isArray(parent.components) ? parent.components.indexOf(blockId) : 0;
+    return Array.isArray(parent.components) ? parent.components.indexOf(blockId) : -1;
   };
 };

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -2,6 +2,7 @@ export const BLOCK_CREATE = 'BLOCK_CREATE';
 export const BLOCK_SAVE = 'BLOCK_SAVE';
 export const BLOCK_CLONE = 'BLOCK_CLONE';
 export const BLOCK_MERGE = 'BLOCK_MERGE';
+export const BLOCK_DELETE = 'BLOCK_DELETE';
 export const BLOCK_RENAME = 'BLOCK_RENAME';
 export const BLOCK_SET_COLOR = 'BLOCK_SET_COLOR';
 export const BLOCK_SET_SBOL = 'BLOCK_SET_SBOL';

--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -10,7 +10,7 @@ import BlockDefinition from '../schemas/Block';
 
 //fetch only supports absolute paths
 //include a check for tests, hardcode for now
-const serverRoot = window.location.protocol ?
+const serverRoot = (/http/gi).test(window.location.protocol) ?
   `${window.location.protocol}//${window.location.host}/` :
   'http://localhost:3000/';
 

--- a/src/reducers/blocks.js
+++ b/src/reducers/blocks.js
@@ -40,6 +40,12 @@ export default function blocks(state = initialState, action) {
     const { block } = action;
     return Object.assign({}, state, {[block.id]: block});
   }
+  case ActionTypes.BLOCK_DELETE : {
+    const { blockId } = action;
+    const nextState = Object.assign({}, state);
+    delete nextState[blockId];
+    return nextState;
+  }
   default : {
     return state;
   }

--- a/test/actions/blocks.js
+++ b/test/actions/blocks.js
@@ -1,10 +1,9 @@
-import chai from 'chai';
+import { expect } from 'chai';
+import range from '../../src/utils/array/range';
 import * as actions from '../../src/actions/blocks';
 import blocksReducer from '../../src/reducers/blocks';
 import { simpleStore } from '../store/mocks';
 import Block from '../../src/models/Block';
-
-const { expect } = chai;
 
 describe('Block Actions', () => {
   const storeBlock = new Block();
@@ -20,10 +19,41 @@ describe('Block Actions', () => {
     expect(inStore).to.eql(created);
   });
 
-  it('blockSetSequence() sets the length', () => {
-    const sequence = 'acgtacgtacgt';
-    blockStore.dispatch(actions.blockSetSequence(storeBlock.id, sequence));
-    const newBlock = blockStore.getState().blocks[storeBlock.id];
-    expect(newBlock.sequence.length).to.equal(sequence.length);
+  describe('Sequence', () => {
+    it('blockSetSequence() sets the length', () => {
+      const sequence = 'acgtacgtacgt';
+      blockStore.dispatch(actions.blockSetSequence(storeBlock.id, sequence))
+        .then(() => {
+          const newBlock = blockStore.getState().blocks[storeBlock.id];
+          expect(newBlock.sequence.length).to.equal(sequence.length);
+        });
+    });
+
+    it('blockSetSequence() validates the sequence');
+  });
+
+  describe.only('Orchestrator / Hierarchy', () => {
+    before(() => {
+      const root = storeBlock.id;
+      range(5).reduce((parentId, index) => {
+        const block = actions.blockCreate();
+        actions.blockAddComponent(parentId, block.id);
+        return block.id;
+      }, root);
+
+      console.log(blockStore.getState());
+    });
+
+    it('blockGetSiblings()', () => {
+
+    });
+
+    it('blockGetParents()', () => {
+
+    });
+
+    it('blockGetIndex()', () => {
+
+    });
   });
 });

--- a/test/actions/blocks.js
+++ b/test/actions/blocks.js
@@ -32,28 +32,53 @@ describe('Block Actions', () => {
     it('blockSetSequence() validates the sequence');
   });
 
-  describe.only('Orchestrator / Hierarchy', () => {
+  describe('Orchestrator / Hierarchy', () => {
+    //in before(), create a tree, where the initial block is the root, with a single lineage, where each node has multiple sibling
+    const depth = 5;
+    const siblings = 3;
+    const root = storeBlock.id;
+    const lineage = [root];
+    let leaf;
+
     before(() => {
-      const root = storeBlock.id;
-      range(5).reduce((parentId, index) => {
-        const block = actions.blockCreate();
-        actions.blockAddComponent(parentId, block.id);
-        return block.id;
+      leaf = range(depth).reduce((parentId, index) => {
+        const blockIds = range(siblings).map(() => {
+          const block = blockStore.dispatch(actions.blockCreate());
+          blockStore.dispatch(actions.blockAddComponent(parentId, block.id));
+          return block.id;
+        });
+
+        const procreator = blockIds[0];
+        lineage.push(procreator);
+
+        return procreator;
       }, root);
-
-      console.log(blockStore.getState());
-    });
-
-    it('blockGetSiblings()', () => {
-
     });
 
     it('blockGetParents()', () => {
+      const parents = blockStore.dispatch(actions.blockGetParents(leaf));
 
+      expect(parents.length).to.equal(depth);
+    });
+
+    it('blockGetSiblings()', () => {
+      const sibs = blockStore.dispatch(actions.blockGetSiblings(leaf));
+      expect(sibs.length).to.equal(siblings);
+
+      const parents = blockStore.dispatch(actions.blockGetParents(leaf));
+      const parentId = parents[0];
+      const parent = blockStore.getState().blocks[parentId];
+      expect(parent.components).to.eql(sibs);
     });
 
     it('blockGetIndex()', () => {
+      const index = blockStore.dispatch(actions.blockGetIndex(leaf));
+      expect(index).to.equal(0);
 
+      const parents = blockStore.dispatch(actions.blockGetParents(leaf));
+      const parentId = parents[0];
+      const parent = blockStore.getState().blocks[parentId];
+      expect(parent.components[0]).to.eql(leaf);
     });
   });
 });

--- a/test/middleware/api.js
+++ b/test/middleware/api.js
@@ -6,7 +6,7 @@ const { expect } = chai;
 
 const fileStoragePath = './storage/';
 
-describe('Middleware', () => {
+describe.only('Middleware', () => {
   //login() is tested in server/REST
 
   it('apiPath() returns an absolute URL to hit the server', () => {
@@ -29,7 +29,9 @@ describe('Middleware', () => {
 
   //todo
 
-  it('writeFile() should take path and string, and write file', (done) => {
+  it('writeFile() should take path and string, and write file', function writeFileBasic(done) {
+    this.timeout(5000);
+
     const filePath = 'test/writeMe';
     const fileContents = 'rawr';
     const storagePath = fileStoragePath + filePath;
@@ -45,7 +47,9 @@ describe('Middleware', () => {
       });
   });
 
-  it('writeFile() shuold delete if contents are null', (done) => {
+  it('writeFile() shuold delete if contents are null', function writeFileDelete(done) {
+    this.timeout(5000);
+
     const filePath = 'test/deletable';
     const fileContents = 'oopsie';
     const storagePath = fileStoragePath + filePath;
@@ -112,47 +116,49 @@ describe('Middleware', () => {
           readFile(file2Path).then(resp => resp.text()),
         ]);
       })
-    .then(files => {
-      expect(files[0]).to.equal(file1Contents);
-      expect(files[1]).to.equal(file2Contents);
-      done();
-    });
-  });
-
-  it('runExtension() works', function genbankTest(done) {
-    this.timeout(100000);
-    let block1 = exampleBlock;
-    let bid1;
-    let input1;
-
-    createBlock(block1)
-      .then((res) => {
-        bid1 = res.id;
-
-        input1 = {
-          'genbank': 'extensions/compute/genbank_to_block/sequence.gb',
-          'sequence': '/api/file/block/' + bid1 + '/sequence',
-        };
-
-        return res;
-      })
-      .then((res) => {
-        return runExtension('genbank_to_block', input1);
-      })
-      .then((output) => {
-        expect(output.block !== undefined);          
-        const block = JSON.parse(output.block);
-        block1.sequence.url = input1.sequence;
-        return saveBlock(block1);
-      })
-      .then((block) => {
-        expect(block.id === bid1);
-        expect(block.sequence.url === input1.sequence);
-        done();
-      })
-      .catch((err) => {
-        expect(false);
+      .then(files => {
+        expect(files[0]).to.equal(file1Contents);
+        expect(files[1]).to.equal(file2Contents);
         done();
       });
-    });
+  });
+
+  /* DEPRECATED
+   it('runExtension() works', function genbankTest(done) {
+   this.timeout(100000);
+   let block1 = exampleBlock;
+   let bid1;
+   let input1;
+
+   createBlock(block1)
+   .then((res) => {
+   bid1 = res.id;
+
+   input1 = {
+   'genbank': 'extensions/compute/genbank_to_block/sequence.gb',
+   'sequence': '/api/file/block/' + bid1 + '/sequence',
+   };
+
+   return res;
+   })
+   .then((res) => {
+   return runExtension('genbank_to_block', input1);
+   })
+   .then((output) => {
+   expect(output.block !== undefined);
+   const block = JSON.parse(output.block);
+   block1.sequence.url = input1.sequence;
+   return saveBlock(block1);
+   })
+   .then((block) => {
+   expect(block.id === bid1);
+   expect(block.sequence.url === input1.sequence);
+   done();
+   })
+   .catch((err) => {
+   expect(false);
+   done();
+   });
+   });
+   */
 });


### PR DESCRIPTION
Adds actions `blockGetParents` `blockGetSiblings` and `blockGetIndex` (though could probably dispose of the latter... thoughts?)
Moves `blockGetSequence` back to a promise
Updates API test + window location retrieval (for production build)