### PR TITLE
added missing requirements to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,5 @@ ENTRYPOINT ["npm"]
 CMD  ["run", "start"]
 
 #everything needed by extensions
-RUN apt-get install -y python python-pip
+RUN apt-get install -y gcc python python-dev python-pip
 RUN yes | pip install biopython
-
-RUN cd ~; perl -MNet::FTP -e '$ftp = new Net::FTP("ftp.ncbi.nlm.nih.gov", Passive => 1); $ftp->login; $ftp->binary; $ftp->get("/entrez/entrezdirect/edirect.zip");' unzip -u -q edirect.zip; rm edirect.zip; export PATH=$PATH:$HOME/edirect; ./edirect/setup.sh


### PR DESCRIPTION
Test by doing the following:

1) stop redis, stop all containers, and clear all your previous containers and images (probably overkill, but that's what I do)
```
sudo service redis-server stop
docker kill $(docker ps -q)
docker rm $(docker ps -a -q)'
docker rmi $(docker images -q)'
```

2) 
```
docker-compose up
```

3) open 0.0.0.0:3000