### PR TITLE
update to npm3 - requires local update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD . /app
 
 #setup node
 ADD package.json /app/package.json
-RUN npm update -g npm
+RUN npm install -g npm
 RUN cd /app && npm install
 
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "webpack": "*"
   },
   "engines": {
-    "node": ">= 4.2.2"
+    "node": ">= 4.2.2",
+    "npm": ">= 3.7.1"
   },
   "dependencies": {
     "bootstrap": "^3.3.6",


### PR DESCRIPTION
Everyone will need to install npm3 locally after merging. Realistically, this doesnt cause any changes yet, except to speed things up a bit, as dependencies are now installed maximally flat