### PR TITLE
Updated compose files with ports and new image name

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,9 +1,9 @@
 genome-designer:
-  image: quay.io/autodesk_bionano/genome-designer-qa
+  image: quay.io/autodesk_bionano/genomedesigner_genome-designer
   links:
     - redis
   ports:
-    - "80:3000"
+    - "3000:3000"
     - "6379:6379"
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ genome-designer:
   links:
     - redis
   ports:
-    - "80:3000"
+    - "3000:3000"
     - "6379:6379"
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
These changes are needed to align with the new build process which will expect the container to have its "native" port exposed (e.g. 3000) and not port 80. Also the name of the docker image won't (at last for now) have the environment name on it.