### PR TITLE
make 'npm install' compatible with Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 
     "test": "rm -rf ./storage/test && NODE_ENV=test mocha --recursive --compilers js:babel-register,css:test/css-null-compiler.js --require ./test/setup.js --timeout=10000",
     "test:watch": "npm test -- --watch",
-    "nightwatch": "./node_modules/nightwatch/bin/nightwatch",
-    "selenium": "./node_modules/selenium-standalone/bin/selenium-standalone install",
+    "nightwatch": "node ./node_modules/nightwatch/bin/nightwatch",
+    "selenium": "node ./node_modules/selenium-standalone/bin/selenium-standalone install",
 
     "start-docker": "docker build -t genome-designer . && docker run --privileged -v /var/run/docker.sock:/run/docker.sock -i -p 3000:3000 -t genome-designer",
     "create-ecoli-db": "python extensions/foundry/ecoli/generate_db.py jdon extensions/foundry/ecoli/ecoli.genes.json extensions/foundry/ecoli.json"


### PR DESCRIPTION
currently, 'npm install' in windows will fail, because the js file can only be run by the command 'node xxx.js' 