### PR TITLE
pull auth package from s3 in dev/qa/prod; docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git
+.gitignore
+.aws
+.idea
+node_modules/
+test-deprecated/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,22 @@ RUN apt-get update && \
 #everything needed by extensions
 RUN yes | pip install biopython
 
+RUN pip install awscli
+
 EXPOSE 3000
 ENV PORT=3000
 
+RUN mkdir /app
 WORKDIR /app
-ADD . /app
 
 #setup node
 ADD package.json /app/package.json
 RUN npm update -g npm && npm install
+
+ADD . /app
 RUN npm run install-extensions
 
 RUN cd /app
 
 # Redis now launch via docker-compose and is referenced via link
-CMD  ["npm" ,"run", "auth"]
+CMD  ["npm" ,"start"]

--- a/bin/local-auth.sh
+++ b/bin/local-auth.sh
@@ -4,8 +4,6 @@ set -e
 VERSION_FILE="./node_modules/bio-user-platform/package.json"
 VERSION="0.4.0"
 
-MODULETMPDIR="/tmp/bio-user-platform/npm"
-
 correct_cwd () {
     if [ ! -f "package.json" ]
     then
@@ -29,9 +27,7 @@ install_platform () {
             return 0
         fi
     fi
-    mkdir -p ${MODULETMPDIR}
-    aws s3 cp s3://bionano-devops-build-artifacts/bio-user-platform/npm/bio-user-platform-${VERSION}.tgz ${MODULETMPDIR}/
-    npm install ${MODULETMPDIR}/bio-user-platform-${VERSION}.tgz
+    npm install git+https://git.autodesk.com:bionano/bio-user-platform.git#v${VERSION}
 }
 
 correct_cwd

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -3,3 +3,5 @@ genome-designer:
     file: docker-compose-common.yml
     service: genome-designer
   image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
+  command:
+    npm run server-auth.sh

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "selenium": "node ./node_modules/selenium-standalone/bin/selenium-standalone install",
     "start-docker": "docker build -t genome-designer . && docker run --privileged -v /var/run/docker.sock:/run/docker.sock -i -p 3000:3000 -t genome-designer",
     "create-ecoli-db": "python extensions/foundry/ecoli/generate_db.py jdon extensions/foundry/ecoli/ecoli.genes.json extensions/foundry/ecoli.json",
-    "auth": "EMAIL=1 ./bin/server-auth.sh",
-    "auth-test": "COMMAND=\"mocha --compilers js:babel-register,css:test/css-null-compiler.js --require ./test/setup.js --timeout=10000 test/server/auth/REST.spec.js\" ./bin/server-auth.sh"
+    "auth": "./bin/local-auth.sh",
+    "auth-test": "COMMAND=\"mocha --compilers js:babel-register,css:test/css-null-compiler.js --require ./test/setup.js --timeout=10000 test/server/auth/REST.spec.js\" ./bin/server-auth.sh",
+    "server-auth": "EMAIL=1 ./bin/server-auth.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit attempts to fix the issue where the genome-designer application cannot pull the authentication module from git.autodesk.com on startup in the dev/qa/prod environments in AWS. It includes:

 * `server-auth.sh` was copied to `local-auth.sh`, which should be used when testing real authentication locally since local environments generally can't access s3
 * install the aws cli into the genome-designer Docker image
 * `server-auth.sh` was changed to use s3 to get the authentication module
 * added a .dockerignore file to avoid copying the node_modules directory (and other files) into the docker image, speeding up building the Docker images locally
 * changed default command for the genome-designer Docker image to `npm start` so the container runs when it may not have access to s3
 * override the genome-designer Docker image command in the quick start configuration that is used in the dev/qa/prod environments, which have access to s3
 * changed ordering in the Dockerfile to add package.json and run npm install before adding the contents of the app directory to avoid unnecessary calls to npm install when any file changes

Unfortunately, it's hard to test running `server-auth.sh` in a Docker container locally since it's not picking up AWS IAM credentials like it would when run in AWS.