### PR TITLE
fix bad command spec and add ENV variable for auth API end-point

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -3,5 +3,7 @@ genome-designer:
     file: docker-compose-common.yml
     service: genome-designer
   image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
+  environment:
+    API_END_POINT: http://10.37.152.116:8080/api
   command:
-    npm run server-auth.sh
+    npm run server-auth


### PR DESCRIPTION
This fixes the command spec for the quick-start configuration and defines the Authentication REST API endpoint via an environment variable.