### PR TITLE
Transactions

### DIFF
--- a/src/components/InputSimple.js
+++ b/src/components/InputSimple.js
@@ -51,10 +51,8 @@ export default class InputSimple extends Component {
       return;
     }
     //escape
-    console.log(event.keyCode, this.refs.input);
     if (event.keyCode === 27) {
       this.props.onEscape && this.props.onEscape();
-      console.log(this.refs.input);
       this.refs.input.blur();
       return;
     }

--- a/src/components/InputSimple.js
+++ b/src/components/InputSimple.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 
 import '../styles/InputSimple.css';
 
@@ -11,6 +11,9 @@ export default class InputSimple extends Component {
     useTextarea: PropTypes.bool,
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    onEscape: PropTypes.func,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -30,17 +33,32 @@ export default class InputSimple extends Component {
     this.refs.input.value = val;
   }
 
+  handleFocus = (event) => {
+    this.props.onFocus && this.props.onFocus(event);
+  };
+  
   handleBlur = (event) => {
     if (this.props.updateOnBlur) {
       this.handleSubmission();
     }
+    this.props.onBlur && this.props.onBlur(event);
   };
 
   handleKeyUp = (event) => {
     if (this.props.readOnly) {
       //todo - shouldn't change the value
       event.preventDefault();
+      return;
     }
+    //escape
+    console.log(event.keyCode, this.refs.input);
+    if (event.keyCode === 27) {
+      this.props.onEscape && this.props.onEscape();
+      console.log(this.refs.input);
+      this.refs.input.blur();
+      return;
+    }
+    //enter
     if (event.keyCode === 13 || !this.props.updateOnBlur) {
       this.handleSubmission();
     }
@@ -63,6 +81,7 @@ export default class InputSimple extends Component {
           placeholder={this.props.placeholder}
           defaultValue={this.props.value || this.props.default}
           onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
           onKeyUp={this.handleKeyUp}/>
         }
         {(!this.props.useTextarea) &&
@@ -73,6 +92,7 @@ export default class InputSimple extends Component {
           placeholder={this.props.placeholder}
           defaultValue={this.props.value || this.props.default}
           onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
           onKeyUp={this.handleKeyUp}/>
         }
       </div>

--- a/src/components/InspectorBlock.js
+++ b/src/components/InspectorBlock.js
@@ -32,15 +32,19 @@ export class InspectorBlock extends Component {
   };
 
   selectColor = (color) => {
+    this.startTransaction();
     this.props.instances.forEach((block) => {
       this.props.blockSetColor(block.id, color);
     });
+    this.endTransaction();
   };
 
   selectSymbol = (symbol) => {
+    this.startTransaction();
     this.props.instances.forEach((block) => {
       this.props.blockSetSbol(block.id, symbol);
     });
+    this.endTransaction();
   };
 
   startTransaction = () => {
@@ -82,7 +86,7 @@ export class InspectorBlock extends Component {
     if (this.props.instances.length === 1) {
       return this.props.instances[0].metadata.name;
     }
-    return null;
+    return '';
   }
 
   /**
@@ -92,7 +96,7 @@ export class InspectorBlock extends Component {
     if (this.props.instances.length === 1) {
       return this.props.instances[0].metadata.description;
     }
-    return null;
+    return '';
   }
 
   currentSequenceLength() {
@@ -162,9 +166,10 @@ export class InspectorBlock extends Component {
 
         {!!annotations.length && (<h4 className="InspectorContent-heading">Contents</h4>)}
         {!!annotations.length && (<div className="InspectorContentBlock-Annotations">
-            {annotations.map(annotation => {
+            {annotations.map((annotation, idx) => {
               return (
-                <span className="InspectorContentBlock-Annotation">
+                <span className="InspectorContentBlock-Annotation"
+                      key={idx}>
                 {annotation.name || annotation.description || '?'}
               </span>
               );

--- a/src/components/InspectorBlock.js
+++ b/src/components/InspectorBlock.js
@@ -1,7 +1,7 @@
-import React, {Component, PropTypes} from 'react';
-import {connect} from 'react-redux';
-import {transact, commit, abort} from '../store/undo/actions';
-import {blockMerge, blockSetColor, blockSetSbol, blockRename} from '../actions/blocks';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { transact, commit, abort } from '../store/undo/actions';
+import { blockMerge, blockSetColor, blockSetSbol, blockRename } from '../actions/blocks';
 import InputSimple from './InputSimple';
 import ColorPicker from './ui/ColorPicker';
 import SymbolPicker from './ui/SymbolPicker';

--- a/src/components/InspectorBlock.js
+++ b/src/components/InspectorBlock.js
@@ -1,6 +1,7 @@
-import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
-import { blockMerge, blockSetColor, blockSetSbol, blockRename } from '../actions/blocks';
+import React, {Component, PropTypes} from 'react';
+import {connect} from 'react-redux';
+import {transact, commit, abort} from '../store/undo/actions';
+import {blockMerge, blockSetColor, blockSetSbol, blockRename} from '../actions/blocks';
 import InputSimple from './InputSimple';
 import ColorPicker from './ui/ColorPicker';
 import SymbolPicker from './ui/SymbolPicker';
@@ -13,6 +14,9 @@ export class InspectorBlock extends Component {
     blockSetSbol: PropTypes.func.isRequired,
     blockMerge: PropTypes.func.isRequired,
     blockRename: PropTypes.func.isRequired,
+    transact: PropTypes.func.isRequired,
+    commit: PropTypes.func.isRequired,
+    abort: PropTypes.func.isRequired,
   };
 
   setBlockName = (name) => {
@@ -37,6 +41,18 @@ export class InspectorBlock extends Component {
     this.props.instances.forEach((block) => {
       this.props.blockSetSbol(block.id, symbol);
     });
+  };
+
+  startTransaction = () => {
+    this.props.transact();
+  };
+
+  endTransaction = (shouldAbort = false) => {
+    if (shouldAbort === true) {
+      this.props.abort();
+      return;
+    }
+    this.props.commit();
   };
 
   /**
@@ -114,6 +130,9 @@ export class InspectorBlock extends Component {
         <InputSimple placeholder="Part Name"
                      readOnly={readOnly}
                      onChange={this.setBlockName}
+                     onFocus={this.startTransaction}
+                     onBlur={this.endTransaction}
+                     onEscape={() => this.endTransaction(true)}
                      value={this.currentName()}/>
 
         <h4 className="InspectorContent-heading">Description</h4>
@@ -121,6 +140,9 @@ export class InspectorBlock extends Component {
                      useTextarea
                      readOnly={readOnly}
                      onChange={this.setBlockDescription}
+                     onFocus={this.startTransaction}
+                     onBlur={this.endTransaction}
+                     onEscape={() => this.endTransaction(true)}
                      updateOnBlur
                      value={this.currentDescription()}/>
 
@@ -159,4 +181,7 @@ export default connect(() => ({}), {
   blockSetSbol,
   blockRename,
   blockMerge,
+  transact,
+  commit,
+  abort,
 })(InspectorBlock);

--- a/src/components/InspectorProject.js
+++ b/src/components/InspectorProject.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { transact, commit, abort } from '../store/undo/actions';
 import { projectRename, projectMerge } from '../actions/projects';
 import InputSimple from './InputSimple';
 
@@ -11,6 +12,9 @@ export class InspectorProject extends Component {
     projectRename: PropTypes.func.isRequired,
     projectMerge: PropTypes.func.isRequired,
     readOnly: PropTypes.bool.isRequired,
+    transact: PropTypes.func.isRequired,
+    commit: PropTypes.func.isRequired,
+    abort: PropTypes.func.isRequired,
   };
 
   setProjectName = (name) => {
@@ -19,8 +23,20 @@ export class InspectorProject extends Component {
 
   setProjectDescription = (description) => {
     if (description !== this.props.instance.metadata.description) {
-      this.props.projectMerge(this.props.instance.id, {metadata: {description}});
+      this.props.projectMerge(this.props.instance.id, { metadata: { description } });
     }
+  };
+
+  startTransaction = () => {
+    this.props.transact();
+  };
+
+  endTransaction = (shouldAbort = false) => {
+    if (shouldAbort === true) {
+      this.props.abort();
+      return;
+    }
+    this.props.commit();
   };
 
   render() {
@@ -31,6 +47,9 @@ export class InspectorProject extends Component {
         <h4 className="InspectorContent-heading">Name</h4>
         <InputSimple placeholder="Project Name"
                      onChange={this.setProjectName}
+                     onFocus={this.startTransaction}
+                     onBlur={this.endTransaction}
+                     onEscape={() => this.endTransaction(true)}
                      readOnly={readOnly}
                      value={instance.metadata.name}/>
 
@@ -38,6 +57,9 @@ export class InspectorProject extends Component {
         <InputSimple placeholder="Project Description"
                      useTextarea
                      onChange={this.setProjectDescription}
+                     onFocus={this.startTransaction}
+                     onBlur={this.endTransaction}
+                     onEscape={() => this.endTransaction(true)}
                      readOnly={readOnly}
                      updateOnBlur
                      value={instance.metadata.description}/>
@@ -49,4 +71,7 @@ export class InspectorProject extends Component {
 export default connect(() => ({}), {
   projectRename,
   projectMerge,
+  transact,
+  commit,
+  abort,
 })(InspectorProject);

--- a/src/components/Inventory/InventoryItem.js
+++ b/src/components/Inventory/InventoryItem.js
@@ -19,6 +19,8 @@ export class InventoryItem extends Component {
       }).isRequired,
     }).isRequired,
     onDrop: PropTypes.func,
+    onDragStart: PropTypes.func,
+    onDragComplete: PropTypes.func,
     onSelect: PropTypes.func,
     forceBlocks: PropTypes.array.isRequired,
     inspectorToggleVisibility: PropTypes.func.isRequired,
@@ -38,6 +40,10 @@ export class InventoryItem extends Component {
     this.mouseTrap.cancelDrag();
     // get global point as starting point for drag
     const globalPoint = this.mouseTrap.mouseToGlobal(event);
+
+    //onDragStart handler
+    this.props.onDragStart && this.props.onDragStart(this.props.item);
+
     // start DND
     DnD.startDrag(this.makeDnDProxy(), globalPoint, {
       item: this.props.item,
@@ -47,6 +53,9 @@ export class InventoryItem extends Component {
         if (this.props.onDrop) {
           return this.props.onDrop(this.props.item, target, position);
         }
+      },
+      onDragComplete: (target, position, payload) => {
+        this.props.onDragComplete && this.props.onDragComplete(payload.item, target, position);
       },
     });
   }
@@ -78,7 +87,6 @@ export class InventoryItem extends Component {
     }
     return proxy;
   }
-
 
   render() {
     const item = this.props.item;

--- a/src/components/Inventory/InventoryList.js
+++ b/src/components/Inventory/InventoryList.js
@@ -1,10 +1,12 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import {transact, commit} from '../../store/undo/actions';
 
 import InventoryItem from './InventoryItem';
 
 import '../../styles/InventoryList.css';
 
-export default class InventoryList extends Component {
+export class InventoryList extends Component {
   static propTypes = {
     inventoryType: PropTypes.string.isRequired,
     items: PropTypes.arrayOf(PropTypes.shape({
@@ -12,10 +14,12 @@ export default class InventoryList extends Component {
     })).isRequired,
     onDrop: PropTypes.func,
     onSelect: PropTypes.func,
+    transact: PropTypes.func,
+    commit: PropTypes.func,
   };
 
   render() {
-    const { items, inventoryType, onDrop, onSelect } = this.props;
+    const { items, inventoryType, onDrop, onSelect, transact, commit } = this.props;
 
     return (
       <div className="InventoryList">
@@ -23,6 +27,8 @@ export default class InventoryList extends Component {
           return (
             <InventoryItem key={item.id}
                            inventoryType={inventoryType}
+                           onDragStart={transact}
+                           onDragComplete={commit}
                            onDrop={onDrop}
                            onSelect={onSelect}
                            item={item}/>
@@ -32,3 +38,8 @@ export default class InventoryList extends Component {
     );
   }
 }
+
+export default connect(() => ({}), {
+  transact,
+  commit,
+})(InventoryList);

--- a/src/containers/graphics/dnd/dnd.js
+++ b/src/containers/graphics/dnd/dnd.js
@@ -49,8 +49,8 @@ class DnD {
     this.lastTarget = null;
 
     //set hooks
-    this.onDrop = options.onDrop || (() => {
-      });
+    this.onDrop = options.onDrop || (() => {});
+    this.onDragComplete = options.onDragComplete || (() => {});
 
     // save the payload for dropping
     this.payload = payload;
@@ -112,28 +112,28 @@ class DnD {
     const globalPosition = this.mouseToGlobal(evt);
     const target = this.findTargetAt(globalPosition);
 
-    if (target && target.options && target.options.drop) {
-      //target.options.drop.call(this, globalPosition, this.payload, evt);
-      //save for sync cleanup...
+    if (target && target.options) {
       const savedPayload = this.payload;
 
-      //call onDrop handler, which will immediately resolve to nothing if wasnt passed in
       Promise.resolve(this.onDrop(target, globalPosition))
         .then((result) => {
           const payload = (typeof result !== 'undefined') ?
-            Object.assign(savedPayload, {item: result}) :
+            Object.assign(savedPayload, { item: result }) :
             savedPayload;
-          target.options.drop.call(this, globalPosition, payload, evt);
-          // ensure lastTarget gets a dragLeave incase they rely on it for cleanup
-          if (target && target.options.dragLeave) {
+
+          //drop handler
+          if (target.options.drop) {
+            target.options.drop.call(this, globalPosition, payload, evt);
+          }
+
+          // ensure lastTarget gets a dragLeave in case they rely on it for cleanup
+          if (target.options.dragLeave) {
             target.options.dragLeave.call(this);
           }
+
+          //completion handler
+          this.onDragComplete(target, globalPosition, payload, evt);
         });
-    } else {
-      // ensure lastTarget gets a dragLeave incase they rely on it for cleanup
-      if (target && target.options.dragLeave) {
-        target.options.dragLeave.call(this);
-      }
     }
 
     this.cancelDrag();

--- a/src/inventory/andrea.js
+++ b/src/inventory/andrea.js
@@ -955,18 +955,21 @@ merge(parts[0], {
       {
         name: 'GFP',
         tags: {},
+        notes: {},
         start: 0,
         end: 50,
       },
       {
         name: 'mCherry',
         tags: {},
+        notes: {},
         start: 40,
         end: 80,
       },
       {
         name: 'BglII',
         tags: {},
+        notes: {},
         sequence: 'agatct',
       },
     ],

--- a/src/inventory/examples/exampleWithAnnotations.js
+++ b/src/inventory/examples/exampleWithAnnotations.js
@@ -25,6 +25,8 @@ export default {
         end: 12,
         name: 'BBa_B0034',
         type: 'BioBrick',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -32,6 +34,8 @@ export default {
         end: 8,
         name: '',
         type: 'conserved',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -39,6 +43,8 @@ export default {
         end: 1146,
         name: 'lacI-LVA',
         type: 'cds',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -46,6 +52,8 @@ export default {
         end: 1146,
         name: 'BBa_C0012',
         type: 'BioBrick',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -53,6 +61,8 @@ export default {
         end: 1146,
         name: 'LVA',
         type: 'tag',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -60,6 +70,8 @@ export default {
         end: 1171,
         name: 'Help:Barcodes',
         type: 'barcode',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -67,6 +79,8 @@ export default {
         end: 1259,
         name: 'BBa_B0010',
         type: 'BioBrick',
+        tags: {},
+        notes: {},
       },
       {
         isForward: false,
@@ -74,6 +88,8 @@ export default {
         end: 1308,
         name: 'BBa_B0015',
         type: 'BioBrick',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -81,6 +97,8 @@ export default {
         end: 1234,
         name: '',
         type: 'stem_loop',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -88,6 +106,8 @@ export default {
         end: 1308,
         name: 'BBa_B0012',
         type: 'BioBrick',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -95,6 +115,8 @@ export default {
         end: 1294,
         name: 'T7 TE',
         type: 'stem_loop',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -102,6 +124,8 @@ export default {
         end: 1308,
         name: '',
         type: 'polya',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -109,6 +133,8 @@ export default {
         end: 1301,
         name: '',
         type: 'stop',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -116,6 +142,8 @@ export default {
         end: 1370,
         name: 'BBa_R0011',
         type: 'BioBrick',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -123,6 +151,8 @@ export default {
         end: 1335,
         name: 'lac O1',
         type: 'operator',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -130,6 +160,8 @@ export default {
         end: 1341,
         name: '-35',
         type: 'promoter',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -137,6 +169,8 @@ export default {
         end: 1358,
         name: 'lac O1',
         type: 'operator',
+        tags: {},
+        notes: {},
       },
       {
         isForward: true,
@@ -144,6 +178,8 @@ export default {
         end: 1364,
         name: '-10',
         type: 'promoter',
+        tags: {},
+        notes: {},
       },
     ],
   },

--- a/src/reducers/testProject.js
+++ b/src/reducers/testProject.js
@@ -4,15 +4,17 @@ import Project from '../models/Project';
 import exampleWithAnnotations from '../inventory/examples/exampleWithAnnotations';
 import dummyBlocks from '../inventory/andrea';
 
+const annotationExample = new Block(exampleWithAnnotations);
+
 const [child1, child2, child3, child4, child5, child6, child7] = dummyBlocks;
 
 const root1 = new Block({
-  components: [exampleWithAnnotations.id, child1.id, child2.id, child3.id],
+  components: [annotationExample.id, child1.id, child2.id, child3.id],
 });
 
 export const blocks = [
   root1,
-  exampleWithAnnotations,
+  annotationExample,
   new Block(child1),
   new Block(Object.assign({}, child2, {
     components: [child4.id, child5.id],

--- a/src/store/undo/ActionTypes.js
+++ b/src/store/undo/ActionTypes.js
@@ -1,6 +1,6 @@
-export const UNDO = 'UNDOABLE_UNDO';
-export const REDO = 'UNDOABLE_REDO';
-export const JUMP = 'UNDOABLE_JUMP';
-export const TRANSACT = 'UNDOABLE_TRANSACT';
-export const COMMIT = 'UNDOABLE_COMMIT';
-export const ABORT = 'UNDOABLE_ABORT';
+export const UNDO = 'UNDO:UNDO';
+export const REDO = 'UNDO:REDO';
+export const JUMP = 'UNDO:JUMP';
+export const TRANSACT = 'UNDO:TRANSACT';
+export const COMMIT = 'UNDO:COMMIT';
+export const ABORT = 'UNDO:ABORT';

--- a/test/store/undo/SectionManager.spec.js
+++ b/test/store/undo/SectionManager.spec.js
@@ -143,6 +143,20 @@ describe('Store', () => {
           expect(manager.getCurrentState()).to.eql(beforeState);
           expect(manager.getCurrentState()).to.eql(manager.getPresent());
         });
+
+        it('commit() outside transaction is idempotent', () => {
+          expect(manager.commit).to.not.throw();
+        });
+
+        it('undo() in transaction ends transaction', () => {
+          expect(manager.inTransaction()).to.equal(false);
+          manager.transact();
+          expect(manager.inTransaction()).to.equal(true);
+          manager.undo();
+          expect(manager.inTransaction()).to.equal(false);
+          manager.commit();
+          expect(manager.inTransaction()).to.equal(false);
+        });
       });
     });
   });

--- a/test/store/undo/SectionManager.spec.js
+++ b/test/store/undo/SectionManager.spec.js
@@ -63,6 +63,7 @@ describe('Store', () => {
 
         it('transact() starts a transaction, doesnt change current state', () => {
           preState = manager.getCurrentState();
+          expect(manager.inTransaction()).to.equal(false);
           manager.transact();
           expect(manager.inTransaction()).to.equal(true);
           expect(manager.getPresent()).to.eql(preState);
@@ -70,6 +71,7 @@ describe('Store', () => {
         });
 
         it('patch() updates transactionState, not present', () => {
+          expect(manager.inTransaction()).to.equal(true);
           manager.patch(txnStateAlt);
           expect(manager.inTransaction()).to.equal(true);
           expect(manager.getPresent()).to.eql(preState);
@@ -89,6 +91,13 @@ describe('Store', () => {
           expect(manager.getPresent()).to.eql(txnState);
           expect(manager.getCurrentState()).to.eql(manager.getPresent());
           expect(manager.getPast().slice().pop()).to.eql(preState);
+        });
+
+        it('commit() does nothing when no changes in transaction, maintains reference', () => {
+          const beforeState = manager.getPresent();
+          manager.transact();
+          manager.commit();
+          expect(manager.getPresent()).to.equal(beforeState);
         });
 
         it('abort() leaves the present state, ends transaction', () => {


### PR DESCRIPTION
Wraps inspector changes (blocks and projects) in transactions
Wraps block drag-drop in transaction

undo/redo/jump end the current transaction. This may need some tuning in the future if it presents problems. But we dont want to clobber the state after you undo with the temporary / incomplete transaction state. therefore, commit / abort in undo manager do not error when not in a transaction.