### PR TITLE
use private DNS for Authentication API HTTP endpoint

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -4,6 +4,6 @@ genome-designer:
     service: genome-designer
   image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
   environment:
-    API_END_POINT: http://10.37.152.116:8080/api
+    API_END_POINT: http://auth${AUTH_ENV_TAG}.bionano.bio:8080/api
   command:
     npm run server-auth


### PR DESCRIPTION
This change isn't urgent, but will be necessary when User Authentication is required for QA and Production environments.

`auth.bionano.bio` and `auth.dev.bionano.bio` point to the same internal IP address in AWS and are private DNS records available only in Bionano AWS VPC Networks.