### PR TITLE
fix Auth error messages and password reset functionality

### DIFF
--- a/bin/local-auth.sh
+++ b/bin/local-auth.sh
@@ -2,7 +2,8 @@
 set -e
 
 VERSION_FILE="./node_modules/bio-user-platform/package.json"
-VERSION="0.4.0"
+VERSION="0.5.0"
+LOCALHOST="http://localhost:3000"
 
 correct_cwd () {
     if [ ! -f "package.json" ]
@@ -40,4 +41,4 @@ then
 fi
 
 echo "executing $TARGET with authentication enabled..."
-BIO_NANO_AUTH=1 ${TARGET}
+BIO_NANO_AUTH=1 HOST_URL=${LOCALHOST} ${TARGET}

--- a/bin/server-auth.sh
+++ b/bin/server-auth.sh
@@ -2,7 +2,7 @@
 set -e
 
 VERSION_FILE="./node_modules/bio-user-platform/package.json"
-VERSION="0.4.0"
+VERSION="0.5.0"
 
 MODULETMPDIR="/tmp/bio-user-platform/npm"
 

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -5,5 +5,6 @@ genome-designer:
   image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
   environment:
     API_END_POINT: http://auth${AUTH_ENV_TAG}.bionano.bio:8080/api
+    HOST_URL: http://genome-designer${AUTH_ENV_TAG}.bionano.autodesk.com
   command:
     npm run server-auth

--- a/server/devServer.js
+++ b/server/devServer.js
@@ -68,6 +68,7 @@ if (process.env.BIO_NANO_AUTH) {
     logoutLanding: false,
     loginLanding: false,
     loginFailure: false,
+    resetForm: "/homepage/reset",
     apiEndPoint: process.env.API_END_POINT || "http://localhost:8080/api",
   };
   app.use(initAuthMiddleware(authConfig));

--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -65,16 +65,7 @@ const headersDelete = (overrides) => merge({}, defaultOptions, {
  Authentication API
  *************************/
 
-const authFetch = (...args) => {
-  return rejectingFetch(...args)
-    .then(resp => resp.json())
-    .then(json => {
-      if (json.message) {
-        return Promise.reject(json);
-      }
-      return json;
-    });
-};
+const authFetch = rejectingFetch;
 
 // login with email and password and set the sessionKey (cookie) for later use
 export const login = (user, password) => {

--- a/src/middleware/rejectingFetch.js
+++ b/src/middleware/rejectingFetch.js
@@ -5,8 +5,15 @@ export default function rejectingFetch(...args) {
   return fetch(...args)
     .then(resp => {
       if (resp.status >= 400) {
-        return Promise.reject(resp);
+        return resp.json()
+          .then(json => {
+            return Promise.reject(json);
+          });
       }
+      return resp;
+    })
+    .then(resp => resp.json())
+    .then(resp => {
       return resp;
     });
 }


### PR DESCRIPTION
Fixes auth error messaging and the password reset functionality by:
* handle >=400 statuses before parsing JSON from response to propagate error messages properly
* use new functionality in bio-user-platform to override the default password reset form