### PR TITLE
Egfad 257

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea
 node_modules
 npm-debug.log
-tests
+screenshots
 e2ereports
 selenium-debug.log
 /redis-stable

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -26,7 +26,7 @@
       "silent": true,
       "screenshots" : {
         "enabled" : true,
-        "path" : "./tests/screenshots"
+        "path" : "./screenshots"
       },
       "desiredCapabilities": {
         "browserName": "chrome",

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -23,6 +23,7 @@ import {
   blockClone,
   blockRemoveComponent,
   blockAddComponent,
+  blockRename,
  } from '../actions/blocks';
  import {
    blockGetParents,
@@ -140,15 +141,21 @@ class GlobalNav extends Component {
    * new project and navigate to new project
    */
   newProject() {
+    // create project and add a default construct
     const project = this.props.projectCreate();
+    // add a construct to the new project
+    const block = this.props.blockCreate();
+    this.props.blockRename(block.id, "New Construct");
+    this.props.projectAddConstruct(project.id, block.id);
+    this.props.focusConstruct(block.id);
     this.props.push(`/project/${project.id}`);
   }
-
   /**
    * add a new construct to the current project
    */
   newConstruct() {
     const block = this.props.blockCreate();
+    this.props.blockRename(block.id, "New Construct");
     this.props.projectAddConstruct(this.props.currentProjectId, block.id);
     this.props.focusConstruct(block.id);
   }
@@ -519,6 +526,7 @@ export default connect(mapStateToProps, {
   projectGetVersion,
   blockCreate,
   blockClone,
+  blockRename,
   inspectorToggleVisibility,
   inventoryToggleVisibility,
   blockRemoveComponent,

--- a/src/containers/ProjectPage.js
+++ b/src/containers/ProjectPage.js
@@ -40,7 +40,6 @@ class ProjectPage extends Component {
     if (!project || !project.metadata) {
       this.props.projectLoad(projectId)
         .catch(err => {
-          debugger;
           this.props.push('/?noredirect=true');
         });
       return (<p>loading project...</p>);

--- a/src/containers/graphics/views/constructViewerCanvas.js
+++ b/src/containers/graphics/views/constructViewerCanvas.js
@@ -6,6 +6,7 @@ import {
   blockCreate,
   blockAddComponent,
   blockClone,
+  blockRename,
 } from '../../../actions/blocks';
 import { focusConstruct, focusBlocks } from '../../../actions/focus';
 import { projectGetVersion } from '../../../selectors/projects';
@@ -30,6 +31,7 @@ export class ConstructViewerCanvas extends Component {
   onDrop(globalPosition, payload, event) {
     // make new construct
     const construct = this.props.blockCreate();
+    this.props.blockRename(construct.id, 'New Construct');
     this.props.projectAddConstruct(this.props.currentProjectId, construct.id);
     const constructViewer = ConstructViewer.getViewerForConstruct(construct.id);
     invariant(constructViewer, 'expect to find a viewer for the new construct');
@@ -89,6 +91,7 @@ export default connect(mapStateToProps, {
   focusBlocks,
   projectAddConstruct,
   blockCreate,
+  blockRename,
   blockAddComponent,
   projectGetVersion,
   blockCreate,

--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -114,6 +114,11 @@ export class ConstructViewer extends Component {
     // handle window resize to reflow the layout
     this.resizeDebounced = debounce(this.windowResized.bind(this), 5);
     window.addEventListener('resize', this.resizeDebounced);
+
+    // if there is no focused construct, then we should focus our construct
+    if (!this.props.focus.construct) {
+      this.props.focusConstruct(this.props.constructId);
+    }
   }
   /**
    * update scene graph after the react component updates

--- a/src/containers/graphics/views/constructvieweruserinterface.js
+++ b/src/containers/graphics/views/constructvieweruserinterface.js
@@ -267,8 +267,9 @@ export default class ConstructViewerUserInterface extends UserInterface {
         default: this.constructViewer.blockSelected([block]); break;
       }
     } else {
-      // clear selections when clicking in the open
-      this.constructViewer.blockSelected([]);
+      // clear block selections and select construct block to make it appear
+      // in the inspector
+      this.constructViewer.blockSelected([this.constructViewer.props.construct.id]);
     }
   }
 

--- a/test-e2e/fixtures/newproject.js
+++ b/test-e2e/fixtures/newproject.js
@@ -6,6 +6,7 @@ var newproject = function(browser) {
     // click new construct menu item
     .click('.menu-dropdown:nth-of-type(1) .menu-item:nth-of-type(2)')
     .waitForElementNotPresent('.menu-header-open', 5000, 'expected a closed menu')
+    .waitForElementPresent('.construct-viewer', 5000, 'expect a construct for the new project')
 };
 
 module.exports = newproject;

--- a/test-e2e/tests/block-delete-context-menu.js
+++ b/test-e2e/tests/block-delete-context-menu.js
@@ -31,19 +31,16 @@ module.exports = {
     // start with a fresh project
     newProject(browser);
 
-    // double check there are no construct viewers present
-    browser.assert.countelements('.construct-viewer', 0);
-
     // create a new construct with a single block
     dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.cvc-drop-target', 10, 10);
 
     browser
-      // expect two construct views with one block each
-      .assert.countelements('.construct-viewer', 1)
+      // expect two construct views with one block
+      .assert.countelements('.construct-viewer', 2)
       .assert.countelements('.sbol-glyph', 1);
 
-
-    var blockBounds = openNthBlockContextMenu(browser, '.sceneGraph', 0);
+    // delete block from second construct viewer
+    var blockBounds = openNthBlockContextMenu(browser, '.construct-viewer:nth-of-type(2) .sceneGraph', 0);
     clickNthContextMenuItem(browser, 3);
 
     // expect the block to be deleted

--- a/test-e2e/tests/block-select.js
+++ b/test-e2e/tests/block-select.js
@@ -32,15 +32,14 @@ module.exports = {
     // start with a fresh project
     newProject(browser);
 
-    // double check there are no construct viewers present
-    browser.assert.countelements('.construct-viewer', 0);
+    // expect one construct
+    browser.assert.countelements('.construct-viewer', 1);
 
-    // create a new construct with a single block
-    dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.cvc-drop-target', 10, 10);
+    // add a single block
+    dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.construct-viewer:nth-of-type(1) .sceneGraph', 30, 30);
 
     browser
-      // expect two construct views with one block each
-      .assert.countelements('.construct-viewer', 1)
+      // expect one block
       .assert.countelements('.sbol-glyph', 1);
 
     // drag some other blocks into the construct

--- a/test-e2e/tests/drag-to-create-construct.js
+++ b/test-e2e/tests/drag-to-create-construct.js
@@ -29,8 +29,8 @@ module.exports = {
     // start with a fresh project
     newProject(browser);
 
-    // double check there are no construct viewers present
-    browser.assert.countelements('.construct-viewer', 0);
+    // expect one construct
+    browser.assert.countelements('.construct-viewer', 1);
 
     // create a new construct with a single block
     dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.cvc-drop-target', 10, 10);
@@ -42,8 +42,8 @@ module.exports = {
     dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.cvc-drop-target', 10, 10);
 
     browser
-      // expect two construct views with one block each
-      .assert.countelements('.construct-viewer', 2)
+      // expect three construct views, two with one block each
+      .assert.countelements('.construct-viewer', 3)
       .assert.countelements('.sbol-glyph', 2)
       // expect SVG elements for each sbol symbol
       .assert.countelements('.construct-viewer svg', 2)

--- a/test-e2e/tests/import-dna-sequence.js
+++ b/test-e2e/tests/import-dna-sequence.js
@@ -33,10 +33,10 @@ module.exports = {
     newProject(browser);
 
     // double check there are no construct viewers present
-    browser.assert.countelements('.construct-viewer', 0);
+    browser.assert.countelements('.construct-viewer', 1);
 
-    // create a new construct with a single sketch block
-    dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.cvc-drop-target', 10, 10);
+    // add block to construct
+    dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.construct-viewer:nth-of-type(1) .sceneGraph', 30, 30);
 
     browser
       // expect one construct view and one block
@@ -70,9 +70,6 @@ module.exports = {
     // now start a new project and ensure the dialog is no operational with no block selected
     // start with a fresh project
     newProject(browser);
-
-    // double check there are no construct viewers present
-    browser.waitForElementNotPresent('.construct-viewer', 5000, 'expect no construct viewers')
 
     // open import DNA from main edit menu
     importDNAFromMainMenu(browser);

--- a/test-e2e/tests/import-genbank-file.js
+++ b/test-e2e/tests/import-genbank-file.js
@@ -22,9 +22,6 @@ module.exports = {
     // start with a new project to ensure no construct viewers are visible
     newProject(browser);
 
-    // double check there are no construct viewers present
-    browser.assert.countelements('.construct-viewer', 0);
-
     // click the file menu -> Upload Genbank File
     clickMainMenu(browser, 1, 5);
 

--- a/test-e2e/tests/new-project-new-construct.js
+++ b/test-e2e/tests/new-project-new-construct.js
@@ -1,0 +1,36 @@
+var homepageRegister = require('../fixtures/homepage-register');
+var signout = require('../fixtures/signout');
+var signin = require('../fixtures/signin');
+var dragFromTo = require('../fixtures/dragfromto');
+var newProject = require('../fixtures/newproject');
+var newConstruct = require('../fixtures/newconstruct');
+var clickMainMenu = require('../fixtures/click-main-menu');
+
+module.exports = {
+  'Test that when creating a new project we get a new focused construct' : function (browser) {
+
+    // maximize for graphical tests
+    browser.windowSize('current', 1200, 900);
+
+    // register via fixture
+    var credentials = homepageRegister(browser);
+
+    // now we can go to the project page
+    browser
+      .url('http://localhost:3000/project/test')
+      // wait for inventory and inspector to be present
+      .waitForElementPresent('.SidePanel.Inventory', 5000, 'Expected Inventory Groups')
+      .waitForElementPresent('.SidePanel.Inspector', 5000, 'Expected Inspector')
+
+    // start with a fresh project
+    newProject(browser);
+
+    browser
+      .pause(1000)
+      // expect one focused construct viewer
+      .assert.countelements(".construct-viewer", 1)
+      // the dark style is only present for unfocused constructs so don't expect it
+      .waitForElementNotPresent('.sceneGraph-dark', 5000, 'expected construct to be focused')
+      .end();
+  }
+};

--- a/test-e2e/tests/test-menu-shortcuts.js
+++ b/test-e2e/tests/test-menu-shortcuts.js
@@ -7,7 +7,7 @@ var newConstruct = require('../fixtures/newconstruct');
 var clickMainMenu = require('../fixtures/click-main-menu');
 
 module.exports = {
-  'Test that we can select empty blocks from the edit menu' : function (browser) {
+  'Test menu shortcuts' : function (browser) {
 
     // maximize for graphical tests
     browser.windowSize('current', 1200, 900);
@@ -37,13 +37,20 @@ module.exports = {
     dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.construct-viewer:nth-of-type(1) .sceneGraph', 300, 30);
     dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.construct-viewer:nth-of-type(1) .sceneGraph', 300, 30);
 
-    // click select empty blocks in main menu
-    clickMainMenu(browser, 2, 11);
+    // now send some keyboard shortcuts to select all and cut the blocks.
+
+    // now paste the blocks
 
     browser
-      .pause(1000)
+      .keys([browser.Keys.COMMAND, 'a'])
       // ensure we have all 3 blocks elements selected
       .assert.countelements(".scenegraph-userinterface-selection", 3)
+      // cut all selected blocks
+      .keys([browser.Keys.NULL, browser.Keys.COMMAND, 'x'])
+      .pause(1000)
+      // expect all selections and blocks to be removed
+      .assert.countelements(".scenegraph-userinterface-selection", 0)
+      .assert.countelements(".sbol-glyph", 0)
       .end();
   }
 };


### PR DESCRIPTION
New Projects always get a new construct named "New Construct" and it is focused.

(NOTE: This always selects the construct in the inspector if you click in the construct viewer but not on any blocks. This is a temporary patch. Max will need to address some inspector issues before we can select constructs as per the spec ).

NOTE: This PR also addresses EGFAD-283