### PR TITLE
Egfad 282

### DIFF
--- a/src/actions/focus.js
+++ b/src/actions/focus.js
@@ -51,10 +51,9 @@ export const focusBlocks = (blocks) => {
 
     if (blocks.length) {
       const firstBlockId = blocks[0];
-      //const siblings = dispatch(BlockSelector.blockGetSiblings(firstBlockId));
-      //invariant(blocks.every(block => siblings.indexOf(block) >= 0), 'must pass siblings, cannot select blocks from multiple levels');
-
-      const constructId = dispatch(BlockSelector.blockGetParentRoot(firstBlockId)).id;
+      const construct = dispatch(BlockSelector.blockGetParentRoot(firstBlockId));
+      // null => no parent => construct (or detached)... undefined could be soething else
+      const constructId = !!construct ? construct.id : (construct !== null ? firstBlockId : undefined);
       if (constructId !== getState().focus.construct || constructId === firstBlockId) {
         dispatch({
           type: ActionTypes.FOCUS_CONSTRUCT,

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -182,6 +182,11 @@ class GlobalNav extends Component {
     const sorted = sortBlocksByIndexAndDepth(this.props.focus.blocks);
     // the right most, top most block is the insertion point
     const highest = sorted.pop();
+    // return parent of highest block and index + 1 so that the block is inserted after the highest block
+    return {
+      parent: this.blockGetParent(this.props.blocks[highest.blockId].id).id,
+      index: highest.index + 1,
+    };
 
     // now locate the block and returns its parent id and the index to start inserting at
     let current = this.props.focus.construct;
@@ -189,7 +194,7 @@ class GlobalNav extends Component {
     let blockIndex = -1;
     let blockParent = null;
     do {
-      blockIndex = highest[index];
+      blockIndex = highest[index].index;
       blockParent = current;
       current = this.props.blocks[current].components[blockIndex];
     } while (++index < highest.length);
@@ -203,9 +208,14 @@ class GlobalNav extends Component {
   // copy the focused blocks to the clipboard using a deep clone
   copyFocusedBlocksToClipboard() {
     if (this.props.focus.blocks.length) {
-      const clones = this.props.focus.blocks.map(block => {
-        return this.props.blockClone(block, this.props.currentProjectId);
+      // sort selected blocks so they are pasted in the same order as they exist now.
+      const sorted = sortBlocksByIndexAndDepth(this.props.focus.blocks);
+      debugger;
+      // sorted is an array of array, flatten while retaining order
+      const clones = sorted.map(info => {
+        return this.props.blockClone(info.blockId, this.props.currentProjectId);
       });
+      // put clones on the clipboard
       this.props.clipboardSetData([clipboardFormats.blocks], [clones])
     }
   }
@@ -240,6 +250,7 @@ class GlobalNav extends Component {
     // paste blocks into construct if format available
     const index = this.props.clipboard.formats.indexOf(clipboardFormats.blocks);
     if (index >= 0) {
+      debugger;
       const blocks = this.props.clipboard.data[index];
       invariant(blocks && blocks.length && Array.isArray(blocks), 'expected array of blocks on clipboard for this format');
       // get current construct
@@ -255,7 +266,7 @@ class GlobalNav extends Component {
       let parentId = construct.id;
       if (this.props.focus.blocks.length) {
         const insertInfo = this.findInsertBlock();
-        insertIndex = insertInfo.blockIndex;
+        insertIndex = insertInfo.index;
         parentId = insertInfo.parent;
       }
       // add to construct

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -50,7 +50,10 @@ import {
   stringToShortcut,
   translate,
 } from '../utils/ui/keyboard-translator';
-import { sortBlocksByIndexAndDepth } from '../utils/ui/uiapi';
+import {
+  sortBlocksByIndexAndDepth,
+  sortBlocksByIndexAndDepthExclude
+} from '../utils/ui/uiapi';
 
 import '../styles/GlobalNav.css';
 
@@ -209,8 +212,10 @@ class GlobalNav extends Component {
   copyFocusedBlocksToClipboard() {
     if (this.props.focus.blocks.length) {
       // sort selected blocks so they are pasted in the same order as they exist now.
-      const sorted = sortBlocksByIndexAndDepth(this.props.focus.blocks);
-      debugger;
+      // NOTE: we don't copy the children of any selected parents since they will
+      // be cloned along with their parent
+      //const sorted = sortBlocksByIndexAndDepth(this.props.focus.blocks);
+      const sorted = sortBlocksByIndexAndDepthExclude(this.props.focus.blocks);
       // sorted is an array of array, flatten while retaining order
       const clones = sorted.map(info => {
         return this.props.blockClone(info.blockId, this.props.currentProjectId);
@@ -250,7 +255,6 @@ class GlobalNav extends Component {
     // paste blocks into construct if format available
     const index = this.props.clipboard.formats.indexOf(clipboardFormats.blocks);
     if (index >= 0) {
-      debugger;
       const blocks = this.props.clipboard.data[index];
       invariant(blocks && blocks.length && Array.isArray(blocks), 'expected array of blocks on clipboard for this format');
       // get current construct

--- a/src/containers/ProjectPage.js
+++ b/src/containers/ProjectPage.js
@@ -45,7 +45,7 @@ class ProjectPage extends Component {
       return (<p>loading project...</p>);
     }
     // build a list of construct viewers
-    const constructViewers = constructs.map(construct => {
+    const constructViewers = constructs.filter(construct => construct).map(construct => {
       return (
         <ConstructViewer key={construct.id}
                          projectId={projectId}

--- a/src/containers/graphics/dnd/dnd.js
+++ b/src/containers/graphics/dnd/dnd.js
@@ -2,6 +2,7 @@ import Vector2D from '../geometry/vector2d';
 import Box2D from '../geometry/box2d';
 import invariant from 'invariant';
 import { transact, commit, abort } from '../../../store/undo/actions';
+import { dispatch } from '../../../store/index';
 
 /**
  * actual Drag and Drop manager.
@@ -58,8 +59,6 @@ class DnD {
     // block selection on anything while dragging
     document.body.classList.add('prevent-selection');
 
-    // open an undo/redo transaction
-    transact();
   }
 
   /**
@@ -117,14 +116,17 @@ class DnD {
           //completion handler
           this.onDragComplete(target, globalPosition, payload, evt);
 
-          // close / commit the undo/redo transaction
-          commit();
+          // close / commit the undo/redo transaction if one is required
+          if (target.options.undoRedoTransaction) {
+            dispatch(commit());
+          }
         });
     } else {
       // abort the undo/redo transaction since nothing is going to change
-      abort();
+      if (target.options.undoRedoTransaction) {
+        dispatch(abort());
+      }
     }
-
     this.cancelDrag();
   }
 

--- a/src/containers/graphics/views/constructvieweruserinterface.js
+++ b/src/containers/graphics/views/constructvieweruserinterface.js
@@ -8,6 +8,9 @@ import Fence from './fence';
 import invariant from 'invariant';
 import { transact, commit, abort } from '../../../store/undo/actions';
 import { dispatch } from '../../../store/index';
+import {
+  sortBlocksByIndexAndDepthExclude
+} from '../../../utils/ui/uiapi';
 
 
 // # of pixels of mouse movement before a drag is triggered.
@@ -357,20 +360,24 @@ export default class ConstructViewerUserInterface extends UserInterface {
         // open an undo/redo transaction
         dispatch(transact());
         // ensure the block being dragged is selected
-        this.constructViewer.blockAddToSelections([block]);
+        // TODO: THIS NEED WORKS, fix later
+        //this.constructViewer.blockAddToSelections([block]);
         // get global point as starting point for drag
         const globalPoint = this.mouseTrap.mouseToGlobal(evt);
         // proxy representing 1 ore more blocks
         const proxy = this.makeDragProxy();
         // remove the blocks, unless meta key pressed
         let copying = evt.altKey;
+        // filter our selected elements so they are in natural order
+        // and with children of selected parents excluded.
+        const blockIds = sortBlocksByIndexAndDepthExclude(this.selectedElements).map(info => info.blockId);
         if (!copying) {
-          this.constructViewer.removePartsList(this.selectedElements);
+          this.constructViewer.removePartsList(blockIds);
         }
         // start the drag with the proxy and the removed block as the payload
         // and indicate that the source of the drag is another construct viewer
         DnD.startDrag(proxy, globalPoint, {
-          item: this.selectedElements,
+          item: blockIds,
           source: 'construct-viewer',
           copying: copying,
           undoRedoTransaction: true,

--- a/src/containers/graphics/views/constructvieweruserinterface.js
+++ b/src/containers/graphics/views/constructvieweruserinterface.js
@@ -6,6 +6,8 @@ import Box2D from '../geometry/box2d';
 import kT from './layoutconstants';
 import Fence from './fence';
 import invariant from 'invariant';
+import { transact, commit, abort } from '../../../store/undo/actions';
+import { dispatch } from '../../../store/index';
 
 
 // # of pixels of mouse movement before a drag is triggered.
@@ -352,6 +354,8 @@ export default class ConstructViewerUserInterface extends UserInterface {
       if (block) {
         // cancel our own mouse operations for now
         this.mouseTrap.cancelDrag();
+        // open an undo/redo transaction
+        dispatch(transact());
         // ensure the block being dragged is selected
         this.constructViewer.blockAddToSelections([block]);
         // get global point as starting point for drag
@@ -369,6 +373,7 @@ export default class ConstructViewerUserInterface extends UserInterface {
           item: this.selectedElements,
           source: 'construct-viewer',
           copying: copying,
+          undoRedoTransaction: true,
         });
       } else {
         // start a fence drag if not over a part

--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -241,7 +241,6 @@ export default class Layout {
    * If the part is an SBOL symbol then use the symbol name preferentially
    */
   partName(part) {
-    return this.blocks[part].id;
     return this.partMeta(part, 'name') || this.partRule(part, 'sbol') || 'block';
   }
   /**

--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -241,6 +241,7 @@ export default class Layout {
    * If the part is an SBOL symbol then use the symbol name preferentially
    */
   partName(part) {
+    return this.blocks[part].id;
     return this.partMeta(part, 'name') || this.partRule(part, 'sbol') || 'block';
   }
   /**

--- a/src/selectors/blocks.js
+++ b/src/selectors/blocks.js
@@ -74,10 +74,11 @@ export const blockGetParents = (blockId) => {
   };
 };
 
-//i.e. get construct
+//i.e. get construct, or null if it is the construct (or detached)
 export const blockGetParentRoot = (blockId) => {
   return (dispatch, getState) => {
-    return _getParents(blockId, getState()).pop();
+    const parents = _getParents(blockId, getState());
+    return parents.length ? parents.pop() : null;
   };
 };
 

--- a/src/utils/ui/uiapi.js
+++ b/src/utils/ui/uiapi.js
@@ -10,14 +10,14 @@ import { dispatch } from '../../store/index';
  * always considered lower than blocks in the parent hierarchy.
  * e.g. given this arrangement of blocks, with selected ones
  * denoted by letters....
- * [ - ][ A ][ - ][ C ][ - ]
+ * [ F ][ A ][ - ][ C ][ - ]
  *        |
  *      [ B ][ - ][ D ]
  *             |
  *           [ E ]
  *
  * After sorting the block [A..E] the order would be:
- * [E, B, D, A, C]
+ * [F, E, B, D, A, C]
  */
 export function sortBlocksByIndexAndDepth(blockIds) {
 
@@ -79,6 +79,25 @@ export function sortBlocksByIndexAndDepth(blockIds) {
   // ( trueIndices is an array of arrays, where the last block is the actual block
   //   and the preceeding blocks are its parents )
   return trueIndices.map(ary => ary.pop());
+};
+
+/**
+ * similar to sortBlocksByIndexAndDepth except that if any of a blocks
+ * parents are in in the list the child is is excluded.
+ */
+export function sortBlocksByIndexAndDepthExclude(blockIds) {
+  // get unfiltered list
+  const list = sortBlocksByIndexAndDepth(blockIds);
+  return list.filter(info => {
+    const parents = dispatch(blockGetParents(info.blockId));
+    let found = false;
+    parents.forEach(parent => {
+      if (list.find(info => info.blockId === parent.id)) {
+        found = true;
+      }
+    });
+    return !found;
+  });
 };
 
 /**

--- a/src/utils/ui/uiapi.js
+++ b/src/utils/ui/uiapi.js
@@ -1,4 +1,84 @@
 import invariant from 'invariant';
+import { blockGetParents } from '../../selectors/blocks';
+import { dispatch } from '../../store/index';
+
+/**
+ * sort blocks according to the position in the
+ * parent construct AND their level of nesting.
+ * Blocks higher in the resulting list are further from the root of
+ * the construct. Blocks at greater depths of nesting are
+ * always considered lower than blocks in the parent hierarchy.
+ * e.g. given this arrangement of blocks, with selected ones
+ * denoted by letters....
+ * [ - ][ A ][ - ][ C ][ - ]
+ *        |
+ *      [ B ][ - ][ D ]
+ *             |
+ *           [ E ]
+ *
+ * After sorting the block [A..E] the order would be:
+ * [E, B, D, A, C]
+ */
+export function sortBlocksByIndexAndDepth(blockIds) {
+
+  const getParents = (blockId) => {
+    return dispatch(blockGetParents(blockId));
+  };
+
+  const getParent = (blockId) => {
+    return getParents(blockId)[0];
+  };
+
+  const hasParent = (blockId) => {
+    return dispatch(blockGetParents(blockId)).length;
+  };
+
+  const getIndex = (blockId) => {
+    const parentBlock = getParent(blockId);
+    invariant(parentBlock, 'expected a parent');
+    const index = parentBlock.components.indexOf(blockId);
+    invariant(index >= 0, 'expect the block to be found in components of parent');
+    return index;
+  };
+
+  /**
+   * path is a representation of length of the path of the given block back to root.
+   * e.g. if the block is the 4th child of a 2nd child of a 5th child its true index would be:
+   *  [ (index in construct) 4, (2nd child of a block in the construct) 1, (4th child of 2nd child of construct) 3]
+   *  [4,1,3]
+   */
+  const getPath = (blockId) => {
+    let path = [];
+    let current = blockId;
+    while (hasParent(current)) {
+      path.unshift(getIndex(current));
+      current = getParent(current).id;
+    }
+    return path;
+  };
+
+  /**
+   * compare two results from getBlockPath, return truthy is a >= b
+   */
+  const compareBlockPaths = (tia, tib) => {
+    let i = 0;
+    while (true) {
+      if (tia[i] === tib[i] && i < tia.length && i < tib.length) {
+        i++;
+      } else {
+        // this works because for each if the two paths are 2/3/2 and 2/3
+        // the final compare of 2 >= null will return true
+        // and also null >= null is true
+        return tia[i] >= tib[i];
+      }
+    }
+  };
+
+  // get true indices of all the focused blocks
+  const trueIndices = blockIds.map(blockId => getPath(blockId));
+  trueIndices.sort(compareBlockPaths);
+  return trueIndices;
+};
 
 /**
  * clear any selected text in the entire document

--- a/src/utils/ui/uiapi.js
+++ b/src/utils/ui/uiapi.js
@@ -51,7 +51,7 @@ export function sortBlocksByIndexAndDepth(blockIds) {
     let path = [];
     let current = blockId;
     while (hasParent(current)) {
-      path.unshift(getIndex(current));
+      path.unshift({blockId: current, index: getIndex(current)});
       current = getParent(current).id;
     }
     return path;
@@ -60,24 +60,25 @@ export function sortBlocksByIndexAndDepth(blockIds) {
   /**
    * compare two results from getBlockPath, return truthy is a >= b
    */
-  const compareBlockPaths = (tia, tib) => {
+  const compareBlockPaths = (infoA, infoB) => {
     let i = 0;
     while (true) {
-      if (tia[i] === tib[i] && i < tia.length && i < tib.length) {
+      if (i < infoA.length && i < infoB.length && infoA[i].index === infoB[i].index) {
         i++;
       } else {
-        // this works because for each if the two paths are 2/3/2 and 2/3
-        // the final compare of 2 >= null will return true
-        // and also null >= null is true
-        return tia[i] >= tib[i];
+        return (i < infoA.length ? infoA[i].index : -1) >= (i < infoB.length ? infoB[i].index : -1);
       }
     }
   };
 
-  // get true indices of all the focused blocks
+
+  // get true indices of all the focused blocks and sort
   const trueIndices = blockIds.map(blockId => getPath(blockId));
   trueIndices.sort(compareBlockPaths);
-  return trueIndices;
+  // return a flattened array of objects with a blockId and its index.
+  // ( trueIndices is an array of arrays, where the last block is the actual block
+  //   and the preceeding blocks are its parents )
+  return trueIndices.map(ary => ary.pop());
 };
 
 /**

--- a/test-e2e/tests/copy-paste.js
+++ b/test-e2e/tests/copy-paste.js
@@ -1,0 +1,42 @@
+var homepageRegister = require('../fixtures/homepage-register');
+var signout = require('../fixtures/signout');
+var signin = require('../fixtures/signin');
+var dragFromTo = require('../fixtures/dragfromto');
+var newProject = require('../fixtures/newproject');
+var newConstruct = require('../fixtures/newconstruct');
+var clickMainMenu = require('../fixtures/click-main-menu');
+
+module.exports = {
+  'Test copy and paste via keyboard for nested test project' : function (browser) {
+
+    // maximize for graphical tests
+    browser.windowSize('current', 1200, 900);
+
+    // register via fixture
+    var credentials = homepageRegister(browser);
+
+    // now we can go to the project page
+    browser
+      .url('http://localhost:3001/project/test')
+      // wait for inventory and inspector to be present
+      .waitForElementPresent('.SidePanel.Inventory', 5000, 'Expected Inventory Groups')
+      .waitForElementPresent('.SidePanel.Inspector', 5000, 'Expected Inspector')
+      // expect to start with 8 blocks
+      .assert.countelements('.sbol-glyph', 8)
+      // send select all
+      .keys([browser.Keys.COMMAND, 'a'])
+      .pause(1000)
+      // send copy
+      .keys([browser.Keys.NULL, browser.Keys.COMMAND, 'c'])
+      .pause(1000)
+      // send new construct
+      .keys([browser.Keys.NULL, browser.Keys.SHIFT, browser.Keys.CONTROL, 'n'])
+      .pause(1000)
+      // paste
+      .keys([browser.Keys.NULL, browser.Keys.COMMAND, 'v'])
+      .pause(1000)
+      // should now have 16 blocks
+      .assert.countelements(".sbol-glyph", 16)
+      .end();
+  }
+};

--- a/test-e2e/tests/undo-redo.js
+++ b/test-e2e/tests/undo-redo.js
@@ -1,0 +1,53 @@
+var homepageRegister = require('../fixtures/homepage-register');
+var signout = require('../fixtures/signout');
+var signin = require('../fixtures/signin');
+var dragFromTo = require('../fixtures/dragfromto');
+var newProject = require('../fixtures/newproject');
+var newConstruct = require('../fixtures/newconstruct');
+var clickMainMenu = require('../fixtures/click-main-menu');
+
+module.exports = {
+  'Test undo / redo after copying a construct' : function (browser) {
+
+    // maximize for graphical tests
+    browser.windowSize('current', 1200, 900);
+
+    // register via fixture
+    var credentials = homepageRegister(browser);
+
+    // now we can go to the project page
+    browser
+      .url('http://localhost:3001/project/test')
+      // wait for inventory and inspector to be present
+      .waitForElementPresent('.SidePanel.Inventory', 5000, 'Expected Inventory Groups')
+      .waitForElementPresent('.SidePanel.Inspector', 5000, 'Expected Inspector')
+      // expect to start with 8 blocks
+      .assert.countelements('.sbol-glyph', 8)
+      // send select all
+      .keys([browser.Keys.COMMAND, 'a'])
+      .pause(1000)
+      // send copy
+      .keys([browser.Keys.NULL, browser.Keys.COMMAND, 'c'])
+      .pause(1000)
+      // send new construct
+      .keys([browser.Keys.NULL, browser.Keys.SHIFT, browser.Keys.CONTROL, 'n'])
+      .pause(1000)
+      // paste
+      .keys([browser.Keys.NULL, browser.Keys.COMMAND, 'v'])
+      .pause(1000)
+      // should now have 16 blocks
+      .assert.countelements(".sbol-glyph", 16)
+      // undo
+      .keys([browser.Keys.NULL, browser.Keys.COMMAND, 'z'])
+      .pause(1000)
+      // back to 8 blocks
+      .assert.countelements(".sbol-glyph", 8)
+      // redo
+      .keys([browser.Keys.NULL, browser.Keys.SHIFT, browser.Keys.COMMAND, 'z'])
+      .pause(1000)
+      // back to 16 blocks
+      .assert.countelements(".sbol-glyph", 16)
+
+      .end();
+  }
+};


### PR DESCRIPTION
- Adds undo/redo transactions to cut/copy/paste and drag and drop operations
- Orders selected blocks according to the natural construct order when selecting for copy/drag. 
- Excludes children from copy/drag selections when the parent is part of the selections.

NOTE: 2 & 3 above are actually a lot more complicated than adding the undo/redo hooks.