### PR TITLE
- Focus can be switched between blocks, construct ( by clicking aways…

### DIFF
--- a/src/components/InspectorBlock.js
+++ b/src/components/InspectorBlock.js
@@ -131,7 +131,7 @@ export class InspectorBlock extends Component {
     return (
       <div className="InspectorContent InspectorContentBlock">
         <h4 className="InspectorContent-heading">Name</h4>
-        <InputSimple placeholder="Part Name"
+        <InputSimple placeholder="Enter a name"
                      readOnly={readOnly}
                      onChange={this.setBlockName}
                      onFocus={this.startTransaction}
@@ -140,7 +140,7 @@ export class InspectorBlock extends Component {
                      value={this.currentName()}/>
 
         <h4 className="InspectorContent-heading">Description</h4>
-        <InputSimple placeholder="Part Description"
+        <InputSimple placeholder="Enter a description"
                      useTextarea
                      readOnly={readOnly}
                      onChange={this.setBlockDescription}

--- a/src/components/ProjectHeader.js
+++ b/src/components/ProjectHeader.js
@@ -1,7 +1,10 @@
 import React, { Component, PropTypes } from 'react';
+import {connect } from 'react-redux';
+import { inspectorToggleVisibility } from '../actions/inspector';
+import { focusConstruct, focusBlocks } from '../actions/focus';
 import '../styles/ProjectHeader.css';
 
-export default class ProjectHeader extends Component {
+class ProjectHeader extends Component {
   static propTypes = {
     project: PropTypes.object.isRequired,
   };
@@ -17,11 +20,17 @@ export default class ProjectHeader extends Component {
     });
   };
 
+  onClick = () => {
+    this.props.inspectorToggleVisibility(true);
+    this.props.focusConstruct();
+    this.props.focusBlocks([]);
+  };
+
   render() {
     const { project } = this.props;
 
     return (
-      <div className="ProjectHeader">
+      <div className="ProjectHeader" onClick={this.onClick}>
         <div className="ProjectHeader-info">
           <div className="ProjectHeader-breadcrumbs">
             <span className="ProjectHeader-breadcrumb ProjectHeader-lead">Projects</span>
@@ -36,3 +45,14 @@ export default class ProjectHeader extends Component {
     );
   }
 }
+
+function mapStateToProps(state, props) {
+  return {
+  };
+}
+
+export default connect(mapStateToProps, {
+  inspectorToggleVisibility,
+  focusConstruct,
+  focusBlocks,
+})(ProjectHeader);

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -39,8 +39,8 @@ import {
   uiToggleDetailView,
   uiSetGrunt,
  } from '../actions/ui';
-import { inspectorToggleVisibility } from '..//actions/inspector';
-import { inventoryToggleVisibility } from '..//actions/inventory';
+import { inspectorToggleVisibility } from '../actions/inspector';
+import { inventoryToggleVisibility } from '../actions/inventory';
 import { uiShowDNAImport } from '../actions/ui';
 
 import KeyboardTrap from 'mousetrap';
@@ -182,7 +182,7 @@ class GlobalNav extends Component {
     iframe.src = url;
     document.body.appendChild(iframe);
   }
-  
+
   /**
    * get parent block of block with given id
    */

--- a/src/containers/Inspector.js
+++ b/src/containers/Inspector.js
@@ -27,6 +27,11 @@ export class Inspector extends Component {
   render() {
     const { isVisible, instances, project, readOnly } = this.props;
 
+    // inspect instances, or construct if no instance or project if no construct or instances
+    let inspect = instances && instances.length
+    ? <InspectorBlock instances={instances} readOnly={readOnly}/>
+  : this.props.constructId ? <InspectorBlock instances={[this.props.blocks[this.props.constructId]]} readOnly={readOnly} />: <InspectorProject instance={project} readOnly={readOnly}/>;
+
     return (
       <div className={'SidePanel Inspector no-vertical-scroll' +
       (isVisible ? ' visible' : '') +
@@ -43,11 +48,7 @@ export class Inspector extends Component {
         </div>
 
         <div className="SidePanel-content">
-          {(instances && instances.length) ?
-            (<InspectorBlock instances={instances}
-                             readOnly={readOnly}/>) :
-            (<InspectorProject instance={project}
-                               readOnly={readOnly}/>) }
+          {inspect}
         </div>
       </div>
     );
@@ -56,7 +57,7 @@ export class Inspector extends Component {
 
 function mapStateToProps(state, props) {
   const { isVisible } = state.inspector;
-  const { forceBlocks, blocks, forceProject } = state.focus;
+  const { forceBlocks, blocks, forceProject, construct } = state.focus;
 
   //use forceBlock if available, otherwise use selected blocks
   const unfilteredInstances = forceBlocks.length ?
@@ -81,9 +82,12 @@ function mapStateToProps(state, props) {
     isVisible,
     readOnly,
     instances,
+    constructId : construct ,
     project,
+    blocks: state.blocks,
   };
 }
+
 
 export default connect(mapStateToProps, {
   inspectorToggleVisibility,

--- a/src/containers/Inspector.js
+++ b/src/containers/Inspector.js
@@ -30,7 +30,7 @@ export class Inspector extends Component {
     // inspect instances, or construct if no instance or project if no construct or instances
     let inspect = instances && instances.length
     ? <InspectorBlock instances={instances} readOnly={readOnly}/>
-  : this.props.constructId ? <InspectorBlock instances={[this.props.blocks[this.props.constructId]]} readOnly={readOnly} />: <InspectorProject instance={project} readOnly={readOnly}/>;
+    : <InspectorProject instance={project} readOnly={readOnly}/>;
 
     return (
       <div className={'SidePanel Inspector no-vertical-scroll' +
@@ -66,7 +66,10 @@ function mapStateToProps(state, props) {
       blocks.map(blockId => state.blocks[blockId]) :
       [];
   //ensure that blocks removed from store dont error / don't pass empty instances
-  const instances = unfilteredInstances.filter(el => !!el);
+  let instances = unfilteredInstances.filter(el => !!el);
+  if (!instances.length && !!construct) {
+    instances = [ state.blocks[construct] ];
+  }
 
   const { projectId } = props; //from routing
   const project = !!forceProject ?
@@ -82,9 +85,7 @@ function mapStateToProps(state, props) {
     isVisible,
     readOnly,
     instances,
-    constructId : construct ,
     project,
-    blocks: state.blocks,
   };
 }
 

--- a/src/containers/graphics/scenegraph2d/node2d.js
+++ b/src/containers/graphics/scenegraph2d/node2d.js
@@ -117,6 +117,13 @@ export default class Node2D {
         this.glyph = value;
         break;
 
+      // apply a data-??? attribute with the given value to our element
+      // value should be {name:'xyz', value:'123'} which would appear in
+      // the dom as data-xyz="123"
+      case 'dataAttribute':
+      this.el.setAttribute(`data-${value.name}`, value.value);
+      break;
+
         // default behaviour is to just set the property
       default: this[key] = props[key];
       }

--- a/src/containers/graphics/views/constructvieweruserinterface.js
+++ b/src/containers/graphics/views/constructvieweruserinterface.js
@@ -80,6 +80,13 @@ export default class ConstructViewerUserInterface extends UserInterface {
     const top = this.topNodeAt(point);
     return top ? this.layout.elementFromNode(top) : null;
   }
+
+  /**
+   * true if the node is the title node for the construct
+   */
+  isConstructTitleNode(node) {
+    return node && this.layout.titleNode === node;
+  }
   /**
    * return the top most block at the given location and whether the point
    * is closer to the left or right edges
@@ -272,9 +279,12 @@ export default class ConstructViewerUserInterface extends UserInterface {
         default: this.constructViewer.blockSelected([block]); break;
       }
     } else {
-      // clear block selections and select construct block to make it appear
-      // in the inspector
+      // clear block selections
       this.constructViewer.blockSelected([]);
+      // if they clicked the title node then select the construct
+      if (this.isConstructTitleNode(this.topNodeAt(point))) {
+        this.selectConstruct();
+      }
     }
   }
 

--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -163,6 +163,7 @@ export default class Layout {
     let node = this.nodeFromElement(part);
     if (!node) {
       const props = Object.assign({}, {
+        dataAttribute: {name: 'nodetype', value: 'block'},
         sg: this.sceneGraph,
       }, appearance);
       props.sbolName = this.isSBOL(part) ? this.blocks[part].rules.sbol : null;
@@ -268,6 +269,7 @@ export default class Layout {
     if (this.showHeader) {
       if (!this.titleNode) {
         this.titleNode = new Node2D(Object.assign({
+          dataAttribute: {name: 'nodetype', value: 'construct-title'},
           sg: this.sceneGraph,
           bounds: new Box2D(this.insetX, this.insetY + kT.bannerHeight, this.sceneGraph.availableWidth - this.insetX, kT.titleH),
         }, kT.titleAppearance));
@@ -276,7 +278,7 @@ export default class Layout {
 
       // update title to current position and text
       this.titleNode.set({
-        text: this.construct.metadata.name || this.construct.id,
+        text: this.construct.metadata.name || 'Construct',
         color: this.baseColor,
       });
     }

--- a/src/styles/ProjectHeader.css
+++ b/src/styles/ProjectHeader.css
@@ -7,6 +7,7 @@
   flex-direction: row;
   justify-content: space-between;
   color: var(--colors-blueGreyLighter);
+  cursor: default;
 
   /* left side */
   &-info {

--- a/test-e2e/fixtures/click-construct-title.js
+++ b/test-e2e/fixtures/click-construct-title.js
@@ -1,0 +1,19 @@
+/**
+ * get the nth block, within the given selector, bounds in document space
+ */
+module.exports = function (browser, constructTitle) {
+
+  // generate mouse move events on body from source to destination
+  browser.execute(function(constructTitle) {
+
+    var node = document.querySelector('[data-construct-title="' + constructTitle + '"]');
+    return node.getBoundingClientRect();
+
+  }, [constructTitle], function(result) {
+    var b = result.value;
+    browser
+      .moveToElement('body', b.left + 10, b.top + 10)
+      .mouseButtonDown(0)
+      .mouseButtonUp(0);
+  });
+}

--- a/test-e2e/tests/focus-block-construct-project.js
+++ b/test-e2e/tests/focus-block-construct-project.js
@@ -1,0 +1,70 @@
+var homepageRegister = require('../fixtures/homepage-register');
+var signout = require('../fixtures/signout');
+var signin = require('../fixtures/signin');
+var dragFromTo = require('../fixtures/dragfromto');
+var newProject = require('../fixtures/newproject');
+var newConstruct = require('../fixtures/newconstruct');
+var clickMainMenu = require('../fixtures/click-main-menu');
+var clickConstructTitle = require('../fixtures/click-construct-title');
+
+module.exports = {
+  'Test that when creating a new project we get a new focused construct' : function (browser) {
+
+    // maximize for graphical tests
+    browser.windowSize('current', 1200, 900);
+
+    // register via fixture
+    var credentials = homepageRegister(browser);
+
+    // now we can go to the project page
+    browser
+      .url('http://localhost:3001/project/test')
+      // wait for inventory and inspector to be present
+      .waitForElementPresent('.SidePanel.Inventory', 5000, 'Expected Inventory Groups')
+      .waitForElementPresent('.SidePanel.Inspector', 5000, 'Expected Inspector')
+
+    // start with a fresh project
+    newProject(browser);
+
+    browser
+      // open inventory and inspector
+      .click('.Inventory-trigger')
+      .waitForElementPresent('.SidePanel.Inventory.visible', 5000, 'Expected inventory to be visible')
+      // open inspector
+      .click('.Inspector-trigger')
+      .waitForElementPresent('.SidePanel.Inspector.visible', 5000, 'Expected inspector to be visible')
+      // click the second inventory group 'EGF Parts' to open it
+      .click('.InventoryGroup:nth-of-type(2) .InventoryGroup-heading')
+      // expect at least one inventory item and one block to drop on
+      .waitForElementPresent('.InventoryItem', 5000, 'expected an inventory item')
+      // expect one focused construct viewer
+      .assert.countelements(".construct-viewer", 1);
+      // drag one block to first construct
+      dragFromTo(browser, '.InventoryItem:nth-of-type(1)', 10, 10, '.construct-viewer:nth-of-type(1) .sceneGraph', 30, 30);
+
+    browser
+      // we should have a single focused block, so changing its text should change the displayed block
+      .clearValue('.Inspector .InputSimple-input')
+      .setValue('.Inspector .InputSimple-input', 'Donald Trump')
+      .pause(500)
+      // expect the construct title to be updated
+      .assert.containsText('[data-nodetype="block"] .nodetext', 'Donald Trump');
+
+    // click the construct title to focus it in inspector
+      clickConstructTitle(browser, 'New Construct');
+    browser
+      .clearValue('.Inspector .InputSimple-input')
+      .setValue('.Inspector .InputSimple-input', 'Hillary Clinton')
+      .pause(500)
+      .assert.containsText('[data-nodetype="construct-title"] .nodetext', 'Hillary Clinton');
+    browser
+      // focus the project and change its title
+      .click('.ProjectHeader')
+      .pause(500)
+      .clearValue('.Inspector .InputSimple-input')
+      .setValue('.Inspector .InputSimple-input', 'Bernie Saunders')
+      .pause(500)
+      .assert.containsText('.ProjectHeader-title', 'Bernie Saunders')
+      .end();
+  }
+};


### PR DESCRIPTION
Focus can be switched between blocks, construct ( by clicking away from blocks or construct title ) and project ( by clicking project header ).

- End to end tests for focus / name changes for blocks, constructs, projects.
- Decorate blocks in the construct viewer with optional data-??? attributes for easier testing