### PR TITLE
added apt-get update to fix build when cached docker layers do not exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Inherit from ubuntu docker image
 FROM ubuntu:14.04
 
-
+RUN apt-get update -y
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 


### PR DESCRIPTION
Seeing build error code of 100 from apt-get install xxx 
This is suggested solution for that: http://askubuntu.com/questions/609223/why-does-this-apt-get-command-work-in-one-context-but-not-the-other

Suspect that now that Jenkins is cleaning up images nightly, build hit this error as it was relying on pre-existing volumes that had performed apt-get update in previous builds.