### PR TITLE
Performance - ability to pause store updates

### DIFF
--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -339,7 +339,7 @@ export const blockAddComponent = (blockId, componentId, index) => {
 };
 
 /**
- * add the array of componentIds into the given part at the given starting index.
+ * add the array of componentIds into the given part at the given starting index. Rather than adding them all at once, dispatch an event for each to ensure we remove from previous parents and stay in a valid state.
  */
 export const blockAddComponents = (blockId, componentIds, index) => {
   return (dispatch, getState) => {

--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -7,6 +7,7 @@ import { saveBlock, loadBlock } from '../middleware/api';
 import * as selectors from '../selectors/blocks';
 import * as projectSelectors from '../selectors/projects';
 import * as undoActions from '../store/undo/actions';
+import { pauseAction, resumeAction } from '../store/pausableStore';
 
 //Promise
 export const blockSave = (blockId, forceProjectId = false) => {
@@ -128,18 +129,12 @@ export const blockClone = (blockInput, parentObjectInput = {}, shallowOnly = fal
       return clone.mutate('components', newComponents);
     });
 
-    //start transaction
-    dispatch(undoActions.transact());
-
     //add clones to the store
-    clones.forEach(block => {
-      dispatch({
-        type: ActionTypes.BLOCK_CLONE,
-        block,
-      });
+    //note, not using the action BLOCK_CLONE
+    dispatch({
+      type: ActionTypes.BLOCK_STASH,
+      blocks: clones,
     });
-
-    dispatch(undoActions.commit());
 
     //return the clone of root passed in
     const rootId = cloneIdMap[oldBlock.id];
@@ -166,6 +161,7 @@ export const blockMerge = (blockId, toMerge) => {
 export const blockDelete = (...blocks) => {
   return (dispatch, getState) => {
     //transact for all blocks
+    dispatch(pauseAction());
     dispatch(undoActions.transact());
 
     blocks.forEach(blockId => {
@@ -187,6 +183,7 @@ export const blockDelete = (...blocks) => {
 
     //end transaction
     dispatch(undoActions.commit());
+    dispatch(resumeAction());
 
     return blocks;
   };
@@ -197,6 +194,7 @@ export const blockDelete = (...blocks) => {
 export const blockDetach = (...blockIds) => {
   return (dispatch, getState) => {
     //transact for all blocks
+    dispatch(pauseAction());
     dispatch(undoActions.transact());
 
     blockIds.forEach(blockId => {
@@ -210,6 +208,7 @@ export const blockDetach = (...blockIds) => {
 
     //end transaction
     dispatch(undoActions.commit());
+    dispatch(resumeAction());
 
     return blockIds;
   };
@@ -285,14 +284,13 @@ export const blockAddSbol = (blockId, sbol) => {
     dispatch(undoActions.transact());
     const oldBlock = getState().blocks[blockId];
     const newBlock = dispatch(blockCreate());
-    dispatch(blockSetSbol(newBlock.id, sbol))
+    dispatch(blockSetSbol(newBlock.id, sbol));
     dispatch(blockAddComponent(oldBlock.id, newBlock.id, oldBlock.components.length));
     //end transaction
     dispatch(undoActions.commit());
     return newBlock;
   };
 };
-
 
 /***************************************
  * Components
@@ -344,6 +342,7 @@ export const blockAddComponent = (blockId, componentId, index) => {
 export const blockAddComponents = (blockId, componentIds, index) => {
   return (dispatch, getState) => {
     //transact for all blocks
+    dispatch(pauseAction());
     dispatch(undoActions.transact());
 
     componentIds.forEach((componentId, subIndex) => {
@@ -352,6 +351,7 @@ export const blockAddComponents = (blockId, componentIds, index) => {
 
     //end transaction
     dispatch(undoActions.commit());
+    dispatch(resumeAction());
 
     return componentIds;
   };

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -115,12 +115,9 @@ export const projectLoad = (projectId) => {
 
         dispatch(undoActions.transact());
 
-        blocks.forEach((blockObject) => {
-          const block = new Block(blockObject);
-          dispatch({
-            type: ActionTypes.BLOCK_LOAD,
-            block,
-          });
+        dispatch({
+          type: ActionTypes.BLOCK_STASH,
+          blocks: blocks.map((blockObject) => new Block(blockObject)),
         });
 
         dispatch({

--- a/src/index.js
+++ b/src/index.js
@@ -21,13 +21,13 @@ Object.assign(exposed, {
   actionTypes,
   api: orchestrator,
   store: {
-    dispatch: store.dispatch,
-    getState: store.getState,
+    ...store,
     lastAction: lastAction,
     subscribe: (callback) => {
       return store.subscribe(() => {
         callback(store.getState(), lastAction());
       });
     },
+    replaceReducer: () => {}, //hide from 3rd party
   },
 });

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -5,6 +5,7 @@ import { routerMiddleware } from 'react-router-redux';
 import { browserHistory } from 'react-router';
 import saveLastActionMiddleware from './saveLastActionMiddleware';
 import combinedReducer from '../reducers/index';
+import pausableStore from './pausableStore';
 
 // note that the store loads the routes, which in turn load components
 // Routes are provided to the store. ReduxRouter works with react-router. see routes.js - they are injected as middleware here so they can be provided to components, and route information can be accessed as application state.
@@ -26,10 +27,14 @@ if (process.env.NODE_ENV !== 'production') {
 
   finalCreateStore = compose(
     applyMiddleware(...middleware),
+    pausableStore(),
     DevTools.instrument()
   )(createStore);
 } else {
-  finalCreateStore = applyMiddleware(...middleware)(createStore);
+  finalCreateStore = compose(
+    applyMiddleware(...middleware),
+    pausableStore()
+  )(createStore);
 }
 
 // expose reducer so you can pass in only one reducer for tests

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -22,7 +22,7 @@ const middleware = [
 ];
 
 let finalCreateStore;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.DEBUGMODE) {
   const DevTools = require('../containers/DevTools.js');
 
   finalCreateStore = compose(

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,8 +14,8 @@ import { getLastAction as lastAction } from './saveLastActionMiddleware';
 
 const store = configureStore();
 
-//in general, you will want to use redux's connect() where possible. This is for 3rd party etc.
-const { dispatch, subscribe, getState } = store;
+//in general, you will want to use redux's connect() where possible. This is in the event you need direct access
+const { dispatch, subscribe, getState, pause, resume, isPaused } = store;
+export { lastAction, dispatch, subscribe, getState, pause, resume, isPaused };
 
-export { lastAction, dispatch, subscribe, getState };
 export default store;

--- a/src/store/pausableStore.js
+++ b/src/store/pausableStore.js
@@ -41,7 +41,7 @@ const patchSubscribe = (options = {}, reducer, createStore, initialState, ...sto
     paused += 1;
 
     if (!!timeoutId) {
-      timeoutId = window.setTimeout(() => resume(), params.timeout);
+      timeoutId = window.setTimeout(() => resume(false, true), params.timeout);
     }
 
     return isPaused();

--- a/src/store/pausableStore.js
+++ b/src/store/pausableStore.js
@@ -1,0 +1,95 @@
+/* store enhancer which lets you pause subscriptions from being called back
+ e.g. if you want to update the store with several actions, but not update components */
+
+export const PAUSE_ACTION = 'PAUSABLE_PAUSE';
+export const RESUME_ACTION = 'PAUSABLE_RESUME';
+
+export const ON_RESUME_ACTION = 'PAUSABLE_ON_RESUME';
+
+const patchSubscribe = (options = {}, reducer, createStore, initialState, ...storeArgs) => {
+  const params = Object.assign({
+    timeout: 1000,
+  }, options);
+
+  let paused = 0;
+  let timeoutId = null;
+
+  const isPaused = () => paused > 0;
+
+  const resume = (preventDispatch = false, reset = false) => {
+    const wasPaused = isPaused();
+    paused = reset === true ?
+      0 :
+      Math.max(0, paused - 1);
+
+    if (wasPaused && !isPaused() && !preventDispatch) {
+      store.dispatch({ type: ON_RESUME_ACTION });
+    }
+
+    if (!isPaused() && !!timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+
+    return isPaused();
+  };
+
+  const pause = () => {
+    paused += 1;
+
+    if (!!timeoutId) {
+      timeoutId = window.setTimeout(() => resume(), params.timeout);
+    }
+
+    return isPaused();
+  };
+
+  const makePausableReducer = (options, reducer) => {
+    return (state, action, ...args) => {
+      switch (action.type) {
+      case PAUSE_ACTION :
+        pause();
+        return state;
+
+      case RESUME_ACTION :
+        const { preventDispatch = false, reset } = action;
+        const wasPaused = isPaused();
+
+        //reducer can't dispatch an action, so don't dispatch using resume(), and just run the reducer instead when appropriate
+        const stillPaused = resume(true, reset);
+
+        if (stillPaused || (!wasPaused && !isPaused()) || preventDispatch === true) {
+          return state;
+        }
+        return reducer(state, action, ...args);
+
+      default :
+        return reducer(state, action, ...args);
+      }
+    };
+  };
+
+  const pausableReducer = makePausableReducer(options, reducer);
+  const store = createStore(pausableReducer, initialState, ...storeArgs);
+
+  return {
+    ...store,
+    subscribe(listener) {
+      function pausableListener(...args) {
+        if (!isPaused()) {
+          listener(...args);
+        }
+      }
+      return store.subscribe(pausableListener);
+    },
+    isPaused,
+    pause,
+    resume,
+  };
+};
+
+export default function pausableStore(options) {
+  return createStore => (reducer, initialState, ...storeArgs) => {
+    return patchSubscribe(options, reducer, createStore, initialState, ...storeArgs);
+  };
+}

--- a/src/store/pausableStore.js
+++ b/src/store/pausableStore.js
@@ -4,6 +4,9 @@
 export const PAUSE_ACTION = 'PAUSABLE_PAUSE';
 export const RESUME_ACTION = 'PAUSABLE_RESUME';
 
+export const pauseAction = () => ({ type: PAUSE_ACTION });
+export const resumeAction = (preventDispatch, reset) => ({ type: RESUME_ACTION, preventDispatch, reset });
+
 export const ON_RESUME_ACTION = 'PAUSABLE_ON_RESUME';
 
 const patchSubscribe = (options = {}, reducer, createStore, initialState, ...storeArgs) => {
@@ -80,6 +83,7 @@ const patchSubscribe = (options = {}, reducer, createStore, initialState, ...sto
           listener(...args);
         }
       }
+
       return store.subscribe(pausableListener);
     },
     isPaused,


### PR DESCRIPTION
Adds a store enhancer so you can pause the store from updating subscriptions, and allows you to dispatch actions to pause / resume. Should have no other side effects.

Applies these actions in some costly operations e.g. loading projects, cloning many blocks, etc.