### PR TITLE
X browser

### DIFF
--- a/plugins/convert/genbank/genbank_export.py
+++ b/plugins/convert/genbank/genbank_export.py
@@ -86,7 +86,7 @@ def build_sequence(block, allblocks):
             block = [b for b in allblocks if b["id"] == component][0]
             seq = seq + build_sequence(block, allblocks)
     else:
-        if block["sequence"]["sequence"]:
+        if "sequence" in block["sequence"] and block["sequence"]["sequence"]:
             seq = block["sequence"]["sequence"]
     return seq
 

--- a/src/containers/graphics/geometry/matrix2d.js
+++ b/src/containers/graphics/geometry/matrix2d.js
@@ -235,6 +235,7 @@ export default class Matrix2D {
    */
   toCSSString() {
     const _v = this._v;
-    return `matrix(${_v[0]}, ${_v[3]}, ${_v[1]}, ${_v[4]}, ${_v[2]}, ${_v[5]})`;
+    // using limited notation since Safari doesn't like a matrix with values like 6.123233995736766e-17
+    return `matrix(${_v[0].toFixed(8)}, ${_v[3].toFixed(8)}, ${_v[1].toFixed(8)}, ${_v[4].toFixed(8)}, ${_v[2].toFixed(8)}, ${_v[5].toFixed(8)})`;
   }
 }

--- a/src/containers/graphics/scenegraph2d/node2d.js
+++ b/src/containers/graphics/scenegraph2d/node2d.js
@@ -121,6 +121,7 @@ export default class Node2D {
       // value should be {name:'xyz', value:'123'} which would appear in
       // the dom as data-xyz="123"
       case 'dataAttribute':
+      this.dataAttribute = value;
       this.el.setAttribute(`data-${value.name}`, value.value);
       break;
 

--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -121,12 +121,14 @@ export class ConstructViewer extends Component {
     window.addEventListener('resize', this.resizeDebounced);
 
     // if there is no focused construct then we should grab it
-    if (!this.props.focus.constructId) {
-      this.props.focusConstruct(this.props.constructId);
-      ReactDOM.findDOMNode(this).scrollIntoView();
-    } else {
-      ReactDOM.findDOMNode(this).scrollIntoView();
-    }
+    // NOTE: For now this is disabled because it often does not product the desired result
+    // and can move the page beyind the scroll limits set.
+    // if (!this.props.focus.constructId) {
+    //   this.props.focusConstruct(this.props.constructId);
+    //   ReactDOM.findDOMNode(this).scrollIntoView();
+    // } else {
+    //   ReactDOM.findDOMNode(this).scrollIntoView();
+    // }
   }
 
   /**

--- a/src/styles/GlobalNav.css
+++ b/src/styles/GlobalNav.css
@@ -10,9 +10,9 @@
     color: white;
     background-color: var(--colors-logo);
     text-align: center;
-    height: var(--GlobalNav-width-chrome);
-    width: var(--GlobalNav-width-chrome);
-    line-height: var(--GlobalNav-width-chrome + 4px);
+    height: var(--GlobalNav-height-chrome);
+    width: var(--GlobalNav-height-chrome);
+    line-height: var(--GlobalNav-height-chrome + 4px);
     text-decoration: none;
     font-size: 1.5rem;
     font-weight: 100;
@@ -20,7 +20,7 @@
 
   &-action {
     padding: 0 1rem 0 1rem;
-    line-height: var(--GlobalNav-width-chrome);
+    line-height: var(--GlobalNav-height-chrome);
     &:not([disabled]):hover {
       cursor: pointer;
       background-color: var(--colors-selected);

--- a/src/styles/ProjectPage.css
+++ b/src/styles/ProjectPage.css
@@ -15,6 +15,7 @@
     width: 0; /* hack - flexbox will give it min-width */
     overflow-y: hidden;
     overflow-x: hidden;
+    /*most of the content on the project page uses overflow-y: scroll, except on chrome this requires an explicit height to work*/
     height: calc(100vh - var(--GlobalNav-height-chrome));
   }
 

--- a/src/styles/ProjectPage.css
+++ b/src/styles/ProjectPage.css
@@ -15,6 +15,7 @@
     width: 0; /* hack - flexbox will give it min-width */
     overflow-y: hidden;
     overflow-x: hidden;
+    height: calc(100vh - var(--GlobalNav-height-chrome));
   }
 
   &-constructs {

--- a/src/styles/SidePanel.css
+++ b/src/styles/SidePanel.css
@@ -8,6 +8,7 @@
   flex-direction: column;
   width: var(--width-SidePanel-closed);
   overflow-x: hidden;
+  height: calc(100vh - var(--GlobalNav-height-chrome));
   top: 0;
   bottom: 0;
   background: var(--colors-blueBlack);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -43,7 +43,7 @@
   --width-SidePanel-closed: 50px;
   --width-SidePanel-open: 300px;
 
-  --GlobalNav-width-chrome: 50px;
+  --GlobalNav-height-chrome: 50px;
 
   /* Backgrounds
  ==================== */


### PR DESCRIPTION
Fixes most of the obvious breaking problems on most browsers:
Todo:

1) On Safari/Firefox the size of the inventory panels is not limited just because they are in a flex column. So the entire panel will start to scroll when the height is exceeded. Not optimal but it works.

2) Mouse selection in the Onion is broken in Safari. Mousedown is ok, but mouse selecting ( dragging ) doesn't work.

FYI. According to spec overflow-y scroll should only work on items with explicit height somewhere in their parentage. I've added calc(100vh - {height of global nav head}) to a couple of major problems there. The same issue exists within some of the inventory sub panels though.