### PR TITLE
remove rogue markup wrapping import genbank dialog

### DIFF
--- a/src/components/genbank/import.js
+++ b/src/components/genbank/import.js
@@ -139,16 +139,13 @@ class ImportGenBankModal extends Component {
                   this.props.uiShowGenBankImport(false);
                 }}>Cancel
               </button>
-
-
             </form>
           )}
           closeOnClickOutside
           closeModal={buttonText => {
             this.props.uiShowGenBankImport(false);
           }}
-        />);
-
+        />
       </div>
     );
   }


### PR DESCRIPTION
This artifact was only on the import genbank/csv dialog. Just some rogue markup that was interpreted as text in html.