### PR TITLE
remove tab focus from inspector buttons

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -24,7 +24,7 @@ class App extends Component {
    */
   componentDidMount() {
     document.addEventListener('keydown', this.rejectBackspace);
-    document.addEventListener('keypress', this.rejectBackspace);
+    document.addEventLiqstener('keypress', this.rejectBackspace);
   }
 
   rejectBackspace(evt) {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -24,7 +24,7 @@ class App extends Component {
    */
   componentDidMount() {
     document.addEventListener('keydown', this.rejectBackspace);
-    document.addEventLiqstener('keypress', this.rejectBackspace);
+    document.addEventListener('keypress', this.rejectBackspace);
   }
 
   rejectBackspace(evt) {

--- a/src/containers/Inspector.js
+++ b/src/containers/Inspector.js
@@ -38,11 +38,11 @@ export class Inspector extends Component {
       (readOnly ? ' readOnly' : '')}>
 
         <div className="SidePanel-heading">
-          <button className="button-nostyle SidePanel-heading-trigger Inspector-trigger"
+          <button tabIndex="-1" className="button-nostyle SidePanel-heading-trigger Inspector-trigger"
                   onClick={() => this.toggle()}/>
           <div className="SidePanel-heading-content">
             <span className="SidePanel-heading-title">Inspector</span>
-            <button className="button-nostyle SidePanel-heading-close"
+            <button tabIndex="-1" className="button-nostyle SidePanel-heading-close"
                     onClick={() => this.toggle(false)}/>
           </div>
         </div>


### PR DESCRIPTION
Best we can do is remove some items from the tab order e.g. the inspector open / close buttons.
However, focus will still be attached to various not interactive elements including:

- Parts of the browser chrome ( e.g. nav bar, toolbars ). Might take 2 or 3 tabs to get back to the app.
- Parts of the onion.

We should open a card for the Onion to ensure tabindex = -1 is set on all buttons/anchors and that his hidden input that he uses for the clipboard does not get focus either.
