### PR TITLE
set global body size limit.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ import morgan from 'morgan';
 import dataRouter from './data/index';
 import fileRouter from './file/index';
 import extensionsRouter from './extensions/index';
+import bodyParser from 'body-parser';
 
 import computeRouter from '../plugins/compute/api';
 import importRouter from '../plugins/convert/import';
@@ -27,6 +28,11 @@ const pathPublic = createBuildPath('public', '../src/public');
 const pathClientBundle = createBuildPath('client.js', '../build/client.js');
 
 const app = express();
+app.use(bodyParser({
+  limit: '50mb',  // default limit is 100K, not nearly large enough for our projects.
+  strict: false,  // accept anything that JSON.parse will swallow
+}));
+
 
 //error logging middleware
 if (process.env.NODE_ENV !== 'production') {

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -37,6 +37,7 @@ export default class Menu extends Component {
               return (
                 item.text ?
                   (<MenuItem
+                    key={index}
                     text={item.text}
                     shortcut={item.shortcut}
                     checked={item.checked}


### PR DESCRIPTION
I suspect JSONParsers in other routes are ignored or overwritten. 
Setting the limit here fixes the issues for project save and probably other routes as well.
Also, give menu items an index to avoid console warning etc.