### PR TITLE
can't change symbol in inspector for constructs

### DIFF
--- a/src/components/Inspector/InspectorBlock.js
+++ b/src/components/Inspector/InspectorBlock.js
@@ -141,6 +141,7 @@ export class InspectorBlock extends Component {
     const { instances, readOnly } = this.props;
     const singleInstance = instances.length === 1;
     const isList = singleInstance && instances[0].isList();
+    const isConstruct = singleInstance && instances[0].isConstruct();
 
     const annotations = this.currentAnnotations();
 
@@ -173,15 +174,15 @@ export class InspectorBlock extends Component {
         <h4 className="InspectorContent-heading">Sequence Length</h4>
         <p><strong>{this.currentSequenceLength()}</strong></p>
 
-        <h4 className="InspectorContent-heading">Color & Symbol</h4>
+        <h4 className="InspectorContent-heading">{'Color' + (!isConstruct ? '& Symbol' : '')}</h4>
         <div className="InspectorContent-pickerWrap">
           <ColorPicker current={this.currentColor()}
                        readOnly={readOnly}
                        onSelect={this.selectColor}/>
 
-          <SymbolPicker current={this.currentRoleSymbol()}
+          {!isConstruct && (<SymbolPicker current={this.currentRoleSymbol()}
                         readOnly={readOnly}
-                        onSelect={this.selectSymbol}/>
+                        onSelect={this.selectSymbol}/>)}
         </div>
 
 

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -46,6 +46,10 @@ export default class Block extends Instance {
    type checks
    ************/
 
+  isConstruct() {
+    return this.components.length > 0;
+  }
+
   isTemplate() {
     return this.rules.fixed === true;
   }


### PR DESCRIPTION
@duncanmeech need to update construct viewer so that symbols are not shown on blocks that are constructs i.e. they have components. There is a function on blocks Block.isConstruct() to check if its a construct. There should not be a lot of scenarios where you have that (since blocks get pushed down from the construct, but just in case)