### PR TITLE
Order schemas

### DIFF
--- a/server/data/index.js
+++ b/server/data/index.js
@@ -124,9 +124,13 @@ router.route('/order/:projectId/:orderId?')
     const { orderId } = req.params;
 
     //todo - if no order ID, get list of orders
+    if (!orderId) {
+      res.status(402).send([]);
+      return;
+    }
 
     //todo - get the order and return it
-    res.status(402).send();
+    res.status(402).send({});
   })
   .post((req, res, next) => {
     const { user, projectId } = req;
@@ -134,10 +138,14 @@ router.route('/order/:projectId/:orderId?')
     const order = req.body;
 
     //todo
-    // validate order
+    // setup validation
     // this should only be called when it is submitted... dont want incomplete ones saved
+    // snapshot project
+    // set project version
+    // validate order
     // add to project folder
-    res.status(402).send();
+    // return the order
+    res.status(402).send({});
   });
 
 router.route('/info/:type/:detail?')

--- a/server/data/index.js
+++ b/server/data/index.js
@@ -139,7 +139,10 @@ router.route('/order/:projectId/:orderId?')
 
     //todo
     // setup validation
-    // this should only be called when it is submitted... dont want incomplete ones saved
+    // attempt to send the order...
+    // convert constructs to part lists
+    // if successful...
+    // set user ID based on request
     // snapshot project
     // set project version
     // validate order

--- a/src/actions/orders.js
+++ b/src/actions/orders.js
@@ -46,7 +46,8 @@ export const orderCreate = (projectId, constructIds = [], parameters = {}) => {
 
     invariant(typeof parameters === 'object', 'paramters must be object');
 
-    const order = new Order(projectId, {
+    const order = new Order({
+      projectId,
       constructIds,
       parameters,
     });
@@ -98,7 +99,7 @@ export const orderGenerateConstructs = (orderId) => {
         });
       });
 
-    const order = oldOrder.merge({ constructs });
+    const order = oldOrder.setConstructs(constructs);
 
     dispatch({
       type: ActionTypes.ORDER_STASH,

--- a/src/inventory/andrea/templates.js
+++ b/src/inventory/andrea/templates.js
@@ -49,6 +49,7 @@ const c = (term) => { //eslint-disable-line id-length
       },
       rules: {
         frozen: true,
+        hidden: true,
       },
     },
   );

--- a/src/inventory/andrea/templates.js
+++ b/src/inventory/andrea/templates.js
@@ -41,7 +41,7 @@ const p = (pos) => { //eslint-disable-line id-length
 // create block which is connector
 // todo - should update connectors themselves to be frozen
 const c = (term) => { //eslint-disable-line id-length
-  const connector = new Block(merge({},
+  const merged = merge({},
     getConnector(term),
     {
       metadata: {
@@ -51,7 +51,9 @@ const c = (term) => { //eslint-disable-line id-length
         frozen: true,
       },
     },
-  ));
+  );
+  delete merged.id;
+  const connector = new Block(merged);
 
   blocksCreated.push(connector);
   return connector;

--- a/src/middleware/order.js
+++ b/src/middleware/order.js
@@ -2,15 +2,28 @@ import rejectingFetch from './rejectingFetch';
 import invariant from 'invariant';
 import { dataApiPath } from './paths';
 import { headersGet, headersPost, headersPut, headersDelete } from './headers';
+import Order from '../models/Order';
 
-// likely want a registry like for inventory and hit their respective functions
+// likely want a registry like for inventory and hit their respective functions for each foundry
 
-export const createOrder = (projectId, order) => {
-  const url = dataApiPath(`order/${projectId}`);
-  const stringified = JSON.stringify(order);
+// todo - handle errors, make consistent
+export const submitOrder = (foundry, order) => {
+  invariant(Order.validateSetup(order), 'order be valid partial order (prior to ID + foundry data)');
+
+  //todo - validate foundry
+
+  const url = dataApiPath(`order/submit`);
+  const stringified = JSON.stringify({
+    foundry,
+    order,
+  });
 
   return rejectingFetch(url, headersPost(stringified))
     .then(resp => resp.json());
+};
+
+const getQuote = (foundry, order) => {
+  invariant(false, 'not implemented');
 };
 
 export const getOrder = (projectId, orderId) => {
@@ -25,14 +38,4 @@ export const getOrders = (projectId) => {
 
   return rejectingFetch(url, headersGet())
     .then(resp => resp.json());
-};
-
-// todo - should this hit our server? Or just go straight to the foudnry
-// todo - handle errors, make consistent
-export const sendOrder = (foundry, order) => {
-  invariant(false, 'not implemented');
-};
-
-const getQuote = (foundry, order) => {
-  invariant(false, 'not implemented');
 };

--- a/src/middleware/order.js
+++ b/src/middleware/order.js
@@ -12,7 +12,7 @@ export const submitOrder = (foundry, order) => {
 
   //todo - validate foundry
 
-  const url = dataApiPath(`order/submit`);
+  const url = dataApiPath(`order/${order.projectId}`);
   const stringified = JSON.stringify({
     foundry,
     order,

--- a/src/models/Instance.js
+++ b/src/models/Instance.js
@@ -48,22 +48,22 @@ export default class Instance {
 
   //clone can accept just an ID (e.g. project), but likely want to pass an object (e.g. block, which also has field projectId in parent)
   clone(parentInfo = {}) {
-    const self = cloneDeep(this);
+    const cloned = cloneDeep(this);
     const inputObject = (typeof parentInfo === 'string') ?
     { version: parentInfo } :
       parentInfo;
 
     const parentObject = Object.assign({
-      id: self.id,
-      version: self.version,
+      id: cloned.id,
+      version: cloned.version,
     }, inputObject);
 
     invariant(versionValidator(parentObject.version), 'must pass a valid version (SHA), got ' + parentObject.version);
 
-    const clone = Object.assign(self, {
-      id: uuid.v4(),
-      parents: [parentObject].concat(self.parents),
+    const clone = Object.assign(cloned, {
+      parents: [parentObject].concat(cloned.parents),
     });
+    delete clone.id;
     return new this.constructor(clone);
   }
 }

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -1,17 +1,19 @@
 import Instance from './Instance';
 import invariant from 'invariant';
-import cloneDeep from 'lodash.clonedeep';
+import { merge, cloneDeep } from 'lodash';
 import OrderDefinition from '../schemas/Order';
 import OrderParametersDefinition from '../schemas/OrderParameters';
+import * as validators from '../schemas/fields/validators';
+import safeValidate from '../schemas/fields/safeValidate';
+
+const idValidator = (id) => safeValidate(validators.id(), true, id);
 
 export default class Order extends Instance {
-  constructor(projectId, projectVersion, input = {}) {
+  constructor(projectId, input = {}) {
     invariant(projectId, 'project is required to make an order');
-    invariant(projectVersion, 'project version required to make an order');
 
     super(input, OrderDefinition.scaffold(), {
       projectId,
-      projectVersion,
     });
   }
 
@@ -24,8 +26,20 @@ export default class Order extends Instance {
     return Object.assign({}, cloneDeep(new Order(input)));
   }
 
+  //validate a complete order (with a project ID, which is after submission)
   static validate(input, throwOnError = false) {
     return OrderDefinition.validate(input, throwOnError);
+  }
+
+  //validate order prior to submission - should have parameters, constructs, user, projectId
+  static validateSetup(input, throwOnError = false) {
+    return idValidator(input.project) &&
+      input.constructIds.length > 0 &&
+      input.constructIds.every(id => idValidator(id)) &&
+      input.constructs.length > 0 &&
+      input.constructs.every(construct => Array.isArray(construct) && construct.every(part => typeof part === 'string')) &&
+      OrderParametersDefinition.validate(input.parameters, throwOnError) &&
+      typeof input.user === 'string';
   }
 
   static validateParameters(input, throwOnError = false) {
@@ -50,15 +64,25 @@ export default class Order extends Instance {
   }
 
   /************
+   parameters, user, other information
+   ************/
+
+  setParameters(parameters = {}, shouldMerge = false) {
+    const nextParameters = merge({}, (shouldMerge === true ? this.parameters : {}), parameters);
+    invariant(OrderParametersDefinition.validate(parameters, false), 'parameters must pass validation');
+    return this.merge({ parameters: nextParameters });
+  }
+
+  /************
    constructs + filtering
    ************/
 
   constructsAdd(...constructs) {
-    //todo
+    //todo - update to expect ID
   }
 
   constructsRemove(...constructs) {
-    //todo
+    //todo - update to expect ID
   }
 
   /************

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -5,6 +5,7 @@ import OrderDefinition from '../schemas/Order';
 import OrderParametersDefinition from '../schemas/OrderParameters';
 import * as validators from '../schemas/fields/validators';
 import safeValidate from '../schemas/fields/safeValidate';
+import { submitOrder, getQuote } from '../middleware/order';
 
 const idValidator = (id) => safeValidate(validators.id(), true, id);
 
@@ -38,8 +39,7 @@ export default class Order extends Instance {
       input.constructIds.every(id => idValidator(id)) &&
       input.constructs.length > 0 &&
       input.constructs.every(construct => Array.isArray(construct) && construct.every(part => typeof part === 'string')) &&
-      OrderParametersDefinition.validate(input.parameters, throwOnError) &&
-      typeof input.user === 'string';
+      OrderParametersDefinition.validate(input.parameters, throwOnError);
   }
 
   static validateParameters(input, throwOnError = false) {
@@ -90,13 +90,15 @@ export default class Order extends Instance {
    ************/
 
   quote(foundry) {
-
+    return getQuote(foundry, this);
   }
 
   submit(foundry) {
-    //set foundry + remote ID in status
+    //todo
+    // set foundry + remote ID in status
     //write it to the server
     //return the updated order
+    return submitOrder(foundry, this);
   }
 
 }

--- a/src/schemas/Block.js
+++ b/src/schemas/Block.js
@@ -3,6 +3,7 @@ import * as validators from './fields/validators';
 import InstanceDefinition from './Instance';
 import SequenceDefinition from './Sequence';
 import RulesDefintion from './Rules';
+import BlockSourceDefinition from './BlockSource';
 
 /**
  @name BlockDefinition
@@ -38,10 +39,7 @@ const BlockDefinition = InstanceDefinition.extend({
   ],
 
   source: [
-    fields.shape({
-      source: validators.string(),
-      id: validators.string(),
-    }).required,
+    BlockSourceDefinition,
     `Source (Inventory) ID of the Part`,
   ],
 

--- a/src/schemas/BlockSource.js
+++ b/src/schemas/BlockSource.js
@@ -1,0 +1,16 @@
+import fields from './fields/index';
+import SchemaDefinition from './SchemaDefinition';
+
+const BlockSourceDefinition = new SchemaDefinition({
+  source: [
+    fields.string().isRequired,
+    `key of foundry the Order has been submitted to`,
+  ],
+
+  id: [
+    fields.string().isRequired,
+    `ID at remote foundry`,
+  ],
+});
+
+export default BlockSourceDefinition;

--- a/src/schemas/BlockSource.js
+++ b/src/schemas/BlockSource.js
@@ -3,12 +3,12 @@ import SchemaDefinition from './SchemaDefinition';
 
 const BlockSourceDefinition = new SchemaDefinition({
   source: [
-    fields.string().isRequired,
+    fields.string(),
     `key of foundry the Order has been submitted to`,
   ],
 
   id: [
-    fields.string().isRequired,
+    fields.string(),
     `ID at remote foundry`,
   ],
 });

--- a/src/schemas/Order.js
+++ b/src/schemas/Order.js
@@ -3,6 +3,7 @@ import * as validators from './fields/validators';
 import SchemaDefinition from './SchemaDefinition';
 import MetadataDefinition from './Metadata';
 import OrderParametersDefinition from './OrderParameters';
+import OrderConstructDefinition from './OrderConstruct';
 import OrderStatusDefinition from './OrderStatus';
 
 const OrderDefinition = new SchemaDefinition({
@@ -24,7 +25,7 @@ const OrderDefinition = new SchemaDefinition({
 
   projectVersion: [
     fields.version().required,
-    'SHA1 version of project when order is made',
+    'SHA1 version of project when order is submitted',
     { avoidScaffold: true },
   ],
 
@@ -33,9 +34,8 @@ const OrderDefinition = new SchemaDefinition({
     `IDs of constructs in project involved in order`,
   ],
 
-  //todo - determine this shape
   constructs: [
-    fields.array().required,
+    fields.arrayOf(OrderConstructDefinition.validate.bind(OrderConstructDefinition)).isRequired,
     `Array of arrays to order - all the constructs with a parts list`,
   ],
 
@@ -45,7 +45,9 @@ const OrderDefinition = new SchemaDefinition({
   ],
 
   user: [
-    fields.object().required,
+    fields.shape({
+      email: validators.email(),
+    }).required,
     'User information',
   ],
 

--- a/src/schemas/Order.js
+++ b/src/schemas/Order.js
@@ -35,7 +35,7 @@ const OrderDefinition = new SchemaDefinition({
   ],
 
   constructs: [
-    fields.arrayOf(OrderConstructDefinition.validate.bind(OrderConstructDefinition)).isRequired,
+    fields.arrayOf(construct => OrderConstructDefinition.validate(construct)).required,
     `Array of arrays to order - all the constructs with a parts list`,
   ],
 
@@ -45,8 +45,9 @@ const OrderDefinition = new SchemaDefinition({
   ],
 
   user: [
-    fields.id({prefix: 'user'}),
+    fields.id({ prefix: 'user' }),
     'User ID',
+    { avoidScaffold: true },
   ],
 
   status: [

--- a/src/schemas/Order.js
+++ b/src/schemas/Order.js
@@ -45,10 +45,8 @@ const OrderDefinition = new SchemaDefinition({
   ],
 
   user: [
-    fields.shape({
-      email: validators.email(),
-    }).required,
-    'User information',
+    fields.id({prefix: 'user'}),
+    'User ID',
   ],
 
   status: [

--- a/src/schemas/OrderConstruct.js
+++ b/src/schemas/OrderConstruct.js
@@ -1,0 +1,23 @@
+import fields from './fields/index';
+import SchemaDefinition from './SchemaDefinition';
+import OrderConstructComponentDefinition from './OrderConstructComponent';
+
+const OrderConstructDefinition = new SchemaDefinition({
+  id: [
+    fields.id({prefix: 'oc'}).isRequired,
+    'ID of order construct',
+  ],
+
+  components: [
+    fields.arrayOf(OrderConstructComponentDefinition.validate.bind(OrderConstructComponentDefinition)).isRequired,
+    'Array of array of all the components, with information about block and source ID',
+  ],
+
+  active: [
+    fields.bool(),
+    'Construct is selected and will be ordered',
+    { scaffold: () => true },
+  ],
+});
+
+export default OrderConstructDefinition;

--- a/src/schemas/OrderConstruct.js
+++ b/src/schemas/OrderConstruct.js
@@ -4,12 +4,12 @@ import OrderConstructComponentDefinition from './OrderConstructComponent';
 
 const OrderConstructDefinition = new SchemaDefinition({
   id: [
-    fields.id({prefix: 'oc'}).isRequired,
+    fields.id({prefix: 'oc'}).required,
     'ID of order construct',
   ],
 
   components: [
-    fields.arrayOf(OrderConstructComponentDefinition.validate.bind(OrderConstructComponentDefinition)).isRequired,
+    fields.arrayOf((comp) => OrderConstructComponentDefinition.validate(comp)).required,
     'Array of array of all the components, with information about block and source ID',
   ],
 

--- a/src/schemas/OrderConstructComponent.js
+++ b/src/schemas/OrderConstructComponent.js
@@ -4,13 +4,13 @@ import BlockSourceDefinition from './BlockSource';
 
 const OrderConstructComponentDefinition = new SchemaDefinition({
   componentId: [
-    fields.id({ prefix: 'block' }).isRequired,
-    `ID of block for this part`,
+    fields.id({ prefix: 'block' }).required,
+    `ID of block for this component`,
   ],
 
   source: [
     BlockSourceDefinition,
-    `Source of part`,
+    `Source of component`,
   ],
 });
 

--- a/src/schemas/OrderConstructComponent.js
+++ b/src/schemas/OrderConstructComponent.js
@@ -4,13 +4,13 @@ import BlockSourceDefinition from './BlockSource';
 
 const OrderConstructComponentDefinition = new SchemaDefinition({
   componentId: [
-    fields.id({prefix: 'block'}).isRequired,
+    fields.id({ prefix: 'block' }).isRequired,
     `ID of block for this part`,
   ],
 
   source: [
-    BlockSourceDefinition
-      `Source of part`,
+    BlockSourceDefinition,
+    `Source of part`,
   ],
 });
 

--- a/src/schemas/OrderConstructComponent.js
+++ b/src/schemas/OrderConstructComponent.js
@@ -1,0 +1,17 @@
+import fields from './fields/index';
+import SchemaDefinition from './SchemaDefinition';
+import BlockSourceDefinition from './BlockSource';
+
+const OrderConstructComponentDefinition = new SchemaDefinition({
+  componentId: [
+    fields.id({prefix: 'block'}).isRequired,
+    `ID of block for this part`,
+  ],
+
+  source: [
+    BlockSourceDefinition
+      `Source of part`,
+  ],
+});
+
+export default OrderConstructComponentDefinition;

--- a/src/schemas/OrderParameters.js
+++ b/src/schemas/OrderParameters.js
@@ -10,6 +10,7 @@ const OrderParametersDefinition = new SchemaDefinition({
   onePot: [
     fields.bool(),
     'Reaction is combinatorial and all parts will be combined in one tube, resulting in many combinatorial assemblies mixed together.',
+    { scaffold: () => true },
   ],
 });
 

--- a/src/schemas/OrderStatus.js
+++ b/src/schemas/OrderStatus.js
@@ -4,14 +4,12 @@ import * as validators from './fields/validators';
 
 const OrderStatusDefinition = new SchemaDefinition({
   foundry: [
-    fields.shape({
-      id: validators.string(),
-    }).isRequired,
+    fields.string().isRequired,
     `key of foundry the Order has been submitted to`,
   ],
 
   remoteId: [
-    fields.string(),
+    fields.string().isRequired,
     `ID at remote foundry`,
   ],
 

--- a/src/schemas/OrderStatus.js
+++ b/src/schemas/OrderStatus.js
@@ -1,6 +1,5 @@
 import fields from './fields/index';
 import SchemaDefinition from './SchemaDefinition';
-import * as validators from './fields/validators';
 
 const OrderStatusDefinition = new SchemaDefinition({
   foundry: [

--- a/src/schemas/fields/createFieldType.js
+++ b/src/schemas/fields/createFieldType.js
@@ -36,6 +36,7 @@ export default function createFieldType(baseFieldDefinition, type) {
 
     const opt = createFieldFromValidator(fieldDef, baseValidator, validationParams, false);
     opt.required = createFieldFromValidator(fieldDef, baseValidator, validationParams, true);
+    opt.isRequired = () => { throw new Error('use required, not isRequired'); };
 
     return opt;
   };

--- a/src/selectors/blocks.js
+++ b/src/selectors/blocks.js
@@ -275,8 +275,8 @@ export const blockGetPositionalCombinations = (blockId, includeUnselected = fals
     //generate 2D array, outer array for positions, inner array with lists of parts
     return _flattenConstruct(blockId, state)
       .map(block => block.isList() ?
-        Object.keys(_getOptions(block.id, state, includeUnselected)) :
-        [block.id]
+        values(_getOptions(block.id, state, includeUnselected)) :
+        [block]
       );
   };
 };

--- a/src/selectors/blocks.js
+++ b/src/selectors/blocks.js
@@ -74,7 +74,7 @@ const _getOptions = (blockId, state, includeUnselected = false) => {
 };
 
 // flattens component hierarchy
-// returns flat array of blocks, ignoring hidden blocks, but not touching list blocks
+// returns flat array of blocks, not touching list blocks
 const _flattenConstruct = (blockId, state) => {
   const block = _getBlockFromStore(blockId, state);
   if (!block.components.length) {
@@ -82,8 +82,7 @@ const _flattenConstruct = (blockId, state) => {
   }
 
   const components = block.components
-    .map(compId => _getBlockFromStore(compId, state))
-    .filter(component => !component.isHidden());
+    .map(compId => _getBlockFromStore(compId, state));
 
   return flatten(components.map(component => component.isConstruct() ?
     _flattenConstruct(component.id, state) :
@@ -244,7 +243,7 @@ export const blockGetFiltered = filters => {
 };
 */
 
-//given a construct, returns an array of parts that have sequence / are list blocks, and are not hidden
+//given a construct, returns an array of parts that have sequence / are list blocks, including hidden blocks
 export const blockFlattenConstruct = (blockId) => {
   return (dispatch, getState) => {
     return _flattenConstruct(blockId, getState());
@@ -252,7 +251,7 @@ export const blockFlattenConstruct = (blockId) => {
 };
 
 /*
- returns 2D array - based on position - of block combinations (omitting hidden blocks), e.g.
+ returns 2D array - based on position - of block combinations (including hidden blocks), e.g.
 
  given:
  A: { sequence }                                        //single part
@@ -282,7 +281,7 @@ export const blockGetPositionalCombinations = (blockId, includeUnselected = fals
 };
 
 /*
- returns 2D array of all possible constructs, flattened, and with options unfurled
+ returns 2D array of all possible constructs, flattened, and with options unfurled, including hidden blocks
 
  given:
  A: { sequence }                                        //single part

--- a/src/store/orchestrator.js
+++ b/src/store/orchestrator.js
@@ -3,7 +3,7 @@ import mapValues from '../utils/object/mapValues';
 
 const dispatchWrapper = (action) => (...args) => dispatch(action(...args));
 
-const sections = ['blocks', 'clipboard', 'projects', 'ui', 'focus', 'inventory', 'inspector'];
+const sections = ['blocks', 'clipboard', 'projects', 'ui', 'focus', 'inventory', 'inspector', 'orders'];
 
 export default sections.reduce((acc, section) => {
   //dont need to use static imports so long as we're using babel...

--- a/test/middleware/rollup.js
+++ b/test/middleware/rollup.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import * as api from '../../src/middleware/data';
+import { range } from 'lodash';
 const { assert, expect } = chai;
 import {
   fileExists,
@@ -10,6 +11,7 @@ import {
   directoryMake,
   directoryDelete
 } from '../../server/utils/fileSystem';
+import Block from '../../src/models/Block';
 
 import * as commitMessages from '../../server/data/commitMessages';
 import * as filePaths from '../../server/utils/filePaths';
@@ -102,11 +104,13 @@ describe('Middleware', () => {
         });
     });
 
-    it.only('can save a huge project (10mb or so)', () => {
+    it('can save a huge project (10mb or so)', () => {
       const roll = createExampleRollup();
       const project = roll.project;
 
-      project.metadata.description = 'thisIsSuperLong'.repeat(1024 * 1024);
+      const newBlocks = range(1000).map(() => new Block());
+
+      roll.blocks = roll.blocks.concat(newBlocks);
 
       return api.saveProject(project.id, roll);
     });

--- a/test/schemas/Block.spec.js
+++ b/test/schemas/Block.spec.js
@@ -4,7 +4,7 @@ import { Block as exampleBlock } from './_examples';
 
 describe('Schema', () => {
   describe('Block', () => {
-    it('should validate the example', () => {
+    it.only('should validate the example', () => {
       expect(BlockDefinition.validate(exampleBlock)).to.equal(true);
     });
 

--- a/test/schemas/Block.spec.js
+++ b/test/schemas/Block.spec.js
@@ -4,7 +4,7 @@ import { Block as exampleBlock } from './_examples';
 
 describe('Schema', () => {
   describe('Block', () => {
-    it.only('should validate the example', () => {
+    it('should validate the example', () => {
       expect(BlockDefinition.validate(exampleBlock)).to.equal(true);
     });
 

--- a/test/schemas/_examples.js
+++ b/test/schemas/_examples.js
@@ -18,7 +18,7 @@ export const Block = {
     annotations: [],
   },
   source: {},
-  options: [],
+  options: {},
   components: [],
   rules: {},
   notes: {},


### PR DESCRIPTION
Lots of changes to order schema, some stubs for ordering middleware, updates to order actions to accomodate new flow:

0 - project is spec (there is a block selector to check each construct)
1 - click order
2 - create an order using `orderCreate()`
3 - open modal, change some things, click submit
4 - from modal, update order with name + order parameters (`orderSetParameters()`)
5 - generate combinations using order (`orderGenerateConstructs()`)
6 - review constructs on second page of modal
7 - submit the order (`orderSubmit()`)
8 - order goes to server, which sends to foundry, and if successful, snapshots project, sets projectVersion, sets userId, saves the order, returns to client
9 - show confirmation order modal 

----

Example flow (from console) to get combations:
```js
let projectId = <current project with a template> ;
let project = gd.api.projects.projectGet(projectId);
let c = gd.api.blocks.blockGet(project.components[0]);
let order = gd.api.orders.orderCreate(project.id, [c.id]);
order = gd.api.orders.orderSetParameters({});
order = gd.api.orders.orderGenerateConstructs(order.id);
```

Order now has a bunch of constructs in it. These are no longer 2D array, but take the form:

```
order.combinations = [
  {
    id: "oc-14e00622-965d-4969-9077-a60d99078ff5",
    active: true, //whether construct is selected or not
    components: [
      {
        componentId: blockId,
        source: {
          id: "conn A-C",
          source: "egf"
        }
      }
    ]
  },
  ...
]

//in construct viewer
const combination = order.combinations[0]; //look at the first one
const construct = new Block({
  components: combination.components.map(comp => comp.componentId)
});
//where construct is just a normal block whose components are a flat list of block IDs