### PR TITLE
block.setSequence can persist source, persist IGEM + EGF sources

### DIFF
--- a/src/inventory/egf/parseResults.js
+++ b/src/inventory/egf/parseResults.js
@@ -37,7 +37,7 @@ export function parseSearchResult(result) {
 export function parseFullResult(result) {
   const { sequence } = result;
   const block = new Block(parseBasicFields(result));
-  return block.setSequence(sequence);
+  return block.setSequence(sequence, false, true);
 }
 
 export function parseResults(results) {

--- a/src/inventory/igem/parseResults.js
+++ b/src/inventory/igem/parseResults.js
@@ -63,7 +63,7 @@ export function parseFullResult(result) {
     },
   };
   const block = new Block(merge(basics, additional));
-  return block.setSequence(sequence);
+  return block.setSequence(sequence, false, true);
 }
 
 export function parseResults(results) {

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -278,9 +278,10 @@ export default class Block extends Instance {
    * @description Writes the sequence for a block
    * @param sequence {String}
    * @param useStrict {Boolean}
+   * @param persistSource {Boolean} Maintain the source of the block
    * @returns {Promise} Promise which resolves with the udpated block
    */
-  setSequence(sequence, useStrict = false) {
+  setSequence(sequence, useStrict = false, persistSource = false) {
     const sequenceLength = sequence.length;
     const sequenceMd5 = md5(sequence);
 
@@ -293,6 +294,8 @@ export default class Block extends Instance {
       return Promise.reject('sequence has invalid characters');
     }
 
+    const updatedSource = persistSource === true ? this.source : { source: 'user', id: null };
+
     return writeSequence(sequenceMd5, sequence, this.id)
       .then(() => {
         const updatedSequence = {
@@ -300,13 +303,11 @@ export default class Block extends Instance {
           length: sequenceLength,
           initialBases: sequence.substr(0, 5),
         };
+
         return this.merge({
           sequence: updatedSequence,
-          source: {
-            source: 'user',
-            id: null,
-          },
-         });
+          source: updatedSource,
+        });
       });
   }
 


### PR DESCRIPTION
was removing source for iGEM and EGF before because they called setSequence when parsing results. allows them to maintain the source when setting sequence.