### PR TITLE
use external storage volume for projects in dev/qa

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -3,7 +3,10 @@ genome-designer:
     file: docker-compose-common.yml
     service: genome-designer
   image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
+  volumes:
+    - /storage/genome-designer/projects:/projects
   environment:
+    STORAGE: /projects
     API_END_POINT: http://auth${AUTH_ENV_TAG}.bionano.bio:8080/api
     HOST_URL: http://genome-designer${AUTH_ENV_TAG}.bionano.autodesk.com
   command:

--- a/server/utils/filePaths.js
+++ b/server/utils/filePaths.js
@@ -2,9 +2,12 @@ import path from 'path';
 import invariant from 'invariant';
 
 const makePath = (...paths) => {
-  if (process.env.BUILD) {
+  if (process.env.STORAGE) {
+    return path.resolve(process.env.STORAGE, ...paths);
+  } else if (process.env.BUILD) {
     return path.resolve(__dirname, '../storage/', ...paths);
   }
+
   return path.resolve(__dirname, '../../storage/', ...paths);
 };
 


### PR DESCRIPTION
This change will only affect dev and qa environments, which have already been provisioned with a separate, persisted storage volume that can be snapshotted and expanded as necessary.