### PR TITLE
default to first option selected if none is selected

### DIFF
--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -174,12 +174,8 @@ export default class Layout {
     }
     // the node representing the parent block
     const parentNode = this.nodeFromElement(block.id);
-    // get the focused list for this block, if any
-    let focusedOptionId = this.focusedOptions[block.id];
-    // if nothing focused then default to the first option
-    if (!focusedOptionId && block.options.length) {
-      focusedOptionId = block.options[0].id;
-    }
+    // get the focused list for this block, or default to first one
+    let focusedOptionId = this.focusedOptions[block.id] || Object.keys(block.options)[0];
     // get only the options that are enabled for this block
     const enabled = Object.keys(block.options).filter(opt => block.options[opt]);
     // if block list is empty add a single placeholder block


### PR DESCRIPTION
This shows the first option if none is selected. But it's not very convincing. You should ensure that when removing an option from a list block that, if it is the focused option, the focus is also reset.