### PR TITLE
Projectload retry

### DIFF
--- a/data/egf_parts/project.js
+++ b/data/egf_parts/project.js
@@ -1,6 +1,6 @@
 import Block from '../../src/models/Block';
 import Project from '../../src/models/Project';
-import { createRollupFromArray } from '../../server/data/rollup';
+import rollupFromArray from '../../src/utils/rollup/rollupFromArray';
 
 import { templates, blocks as templateBlocks } from './templates';
 import { examples, blocks as exampleBlocks } from './examples';
@@ -40,5 +40,5 @@ export default function makeEgfRollup() {
   const blockIds = blocks.constructs.map(block => block.id);
   const project = makeProject(blockIds);
 
-  return createRollupFromArray(project, ...blocks.constructs, ...blocks.blocks);
+  return rollupFromArray(project, ...blocks.constructs, ...blocks.blocks);
 }

--- a/server/auth/userSetup.js
+++ b/server/auth/userSetup.js
@@ -1,27 +1,15 @@
-import Block from '../../src/models/Block';
-import Project from '../../src/models/Project';
 import * as rollup from '../data/rollup';
 import * as querying from '../data/querying';
 import makeEgfRollup from '../../data/egf_parts/project';
-import { createRollupFromArray } from '../../server/data/rollup';
-
-const makeEmptyRollup = () => {
-  //use classless when creating so they are not frozen. If they are frozen, may run into issues when writing
-  const construct = Block.classless();
-  const project = Project.classless({
-    components: [construct.id],
-  });
-
-  return createRollupFromArray(project, construct);
-};
+import rollupWithConstruct from '../../src/utils/rollup/rollupWithConstruct';
 
 //create the EGF project for them
 const createInitialData = (user) => {
-  console.log('[EGF ROLLUP] making rollup ' + egfRollup.project.id + ' for user ' + user.uuid);
   const egfRollup = makeEgfRollup();
+  console.log('[EGF ROLLUP] made rollup ' + egfRollup.project.id + ' for user ' + user.uuid);
   //console.log(egfRollup);
 
-  const emptyProjectRollup = makeEmptyRollup();
+  const emptyProjectRollup = rollupWithConstruct(true);
 
   return Promise.all([
     rollup.writeProjectRollup(emptyProjectRollup.project.id, emptyProjectRollup, user.uuid),

--- a/server/data/persistence.js
+++ b/server/data/persistence.js
@@ -418,7 +418,8 @@ export const projectDelete = (projectId, forceDelete = false) => {
        */
 
       //MOVE TO TRASH FOLDER
-      return directoryMove(projectPath, trashPath);
+      return directoryDelete(trashPath)
+        .then(() => directoryMove(projectPath, trashPath));
     })
     //no need to commit... its deleted (and permissions out of scope of data folder)
     .then(() => projectId);

--- a/server/data/rollup.js
+++ b/server/data/rollup.js
@@ -5,12 +5,6 @@ import { validateBlock, validateProject } from '../utils/validation';
 import { getAllBlocksInProject } from './querying';
 import { values } from 'lodash';
 
-//for use when want to pass an array of blocks
-export const createRollupFromArray = (project, ...blocks) => ({
-  project,
-  blocks: blocks.reduce((acc, block) => Object.assign(acc, { [block.id]: block }), {}),
-});
-
 export const getProjectRollup = (projectId) => {
   //dont use Promise.all so we can handle errors of project not existing better
   return persistence.projectGet(projectId)

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -36,6 +36,13 @@ export const projectList = () => {
 export const projectDelete = (projectId) => {
   return (dispatch, getState) => {
     return deleteProject(projectId)
+      //catch deleting a project that is not saved (will 404)
+      .catch(resp => {
+        if (resp.status === 404) {
+          return null;
+        }
+        return Promise.reject(resp);
+      })
       .then(() => {
         //don't delete the blocks, as they may be shared between projects (or, could delete and then force loading for next / current project)
         dispatch({

--- a/src/components/Inventory/InventoryProject.js
+++ b/src/components/Inventory/InventoryProject.js
@@ -59,7 +59,6 @@ export class InventoryProject extends Component {
   loadProject = (projectId) => {
     //for now, just load the whole project and stick it in the store
     //need to ensure things like blockClone will work on drag. Simplifies browsing of project.
-    //todo - caching, at top level, only load blocks into store when needed
     //could delegate loading of construct components to InventoryConstruct, and load only one level deep
     return this.props.projectLoad(projectId);
   };

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -246,6 +246,8 @@ class GlobalNav extends Component {
       const projectId = this.props.currentProjectId;
       //load another project, avoiding this one
       this.props.projectLoad(null, false, [projectId])
+        //open the new project, skip saving the previous one
+        .then(project => this.props.projectOpen(project.id, true))
         //delete after we've navigated so dont trigger project page to complain about not being able to laod the project
         .then(() => this.props.projectDelete(projectId));
     }

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -244,23 +244,8 @@ class GlobalNav extends Component {
       this.props.uiSetGrunt('This is a sample project and cannot be deleted.');
     } else {
       const projectId = this.props.currentProjectId;
-      //todo - this is copied from projectPage - should de-dupe
-      this.props.projectList()
-        .then(manifests => manifests.filter(manifest => manifest.id !== projectId))
-        .then(manifests => {
-          if (manifests.length) {
-            const nextId = manifests[0].id;
-            //need to fully load the project, as we just have the manifest right now...
-            //otherwise no blocks will show
-            //ideally, this would just get ids
-            this.props.projectLoad(nextId)
-              .then(() => this.props.projectOpen(nextId, true));
-          } else {
-            //if no manifests, create a new project
-            const newProject = this.props.projectCreate();
-            this.props.projectOpen(newProject.id, true);
-          }
-        })
+      //load another project, avoiding this one
+      this.props.projectLoad(null, false, [projectId])
         //delete after we've navigated so dont trigger project page to complain about not being able to laod the project
         .then(() => this.props.projectDelete(projectId));
     }

--- a/src/containers/ProjectPage.js
+++ b/src/containers/ProjectPage.js
@@ -72,27 +72,11 @@ class ProjectPage extends Component {
 
     //handle project not loaded
     if (!project || !project.metadata) {
-      this.props.projectLoad(projectId)
-        .catch(err => {
-          //if couldnt load project, load manifests and display the first one, or create a new project
-          if (projectId) {
-            this.props.uiSetGrunt(`Project with ID ${projectId} could not be loaded, loading another instead...`);
+      this.props.projectLoad(projectId, false, [])
+        .then(project => {
+          if (project.id !== projectId) {
+            this.props.projectOpen(project.id);
           }
-
-          this.props.projectList().then(manifests => {
-            if (manifests.length) {
-              const nextId = manifests[0].id;
-              //need to fully load the project, as we just have the manifest right now...
-              //otherwise no blocks will show
-              //ideally, this would just get ids
-              this.props.projectLoad(nextId)
-                .then(() => this.props.projectOpen(nextId));
-            } else {
-              //if no manifests, create a new project
-              const newProject = this.props.projectCreate();
-              this.props.projectOpen(newProject.id);
-            }
-          });
         });
       return (<p>loading project...</p>);
     }

--- a/src/containers/ProjectPage.js
+++ b/src/containers/ProjectPage.js
@@ -4,6 +4,7 @@ import ConstructViewer from './graphics/views/constructviewer';
 import ConstructViewerCanvas from './graphics/views/constructViewerCanvas';
 import ProjectDetail from '../components/ProjectDetail';
 import ProjectHeader from '../components/ProjectHeader';
+import Spinner from '../components/ui/Spinner';
 import Inventory from './Inventory';
 import Inspector from './Inspector';
 import { projectList, projectLoad, projectCreate, projectOpen } from '../actions/projects';
@@ -72,13 +73,14 @@ class ProjectPage extends Component {
 
     //handle project not loaded
     if (!project || !project.metadata) {
-      this.props.projectLoad(projectId, false, [])
+      debugger;
+      this.props.projectLoad(projectId, false, true)
         .then(project => {
           if (project.id !== projectId) {
             this.props.projectOpen(project.id);
           }
         });
-      return (<p>loading project...</p>);
+      return (<Spinner />);
     }
 
     // build a list of construct viewers

--- a/src/utils/rollup/rollupFromArray.js
+++ b/src/utils/rollup/rollupFromArray.js
@@ -1,0 +1,7 @@
+//for use when want to pass an array of blocks
+export default function rollupFromArray(project, ...blocks) {
+  return {
+    project,
+    blocks: blocks.reduce((acc, block) => Object.assign(acc, { [block.id]: block }), {}),
+  };
+}

--- a/src/utils/rollup/rollupWithConstruct.js
+++ b/src/utils/rollup/rollupWithConstruct.js
@@ -1,0 +1,13 @@
+import Block from '../../models/Block';
+import Project from '../../models/Project';
+import rollupFromArray from './rollupFromArray';
+
+export default function rollupWithConstruct(useClassless = false) {
+  const construct = useClassless ? Block.classless() : new Block();
+  const input = {
+    components: [construct.id],
+  };
+  const project = useClassless ? Project.classless(input) : new Project(input);
+
+  return rollupFromArray(project, construct);
+}

--- a/test/utils/rollup.js
+++ b/test/utils/rollup.js
@@ -1,7 +1,6 @@
 import Project from '../../src/models/Project';
 import Block from '../../src/models/Block';
-
-import * as rollup from '../../server/data/rollup';
+import rollupFromArray from '../../src/utils/rollup/rollupFromArray';
 
 export const numberBlocksInRollup = 7;
 
@@ -43,6 +42,6 @@ export const createExampleRollup = () => {
   //assign the project ID, as it should be there anyway, and will be there after writing
   blocks.forEach(block => Object.assign(block, { projectId: project.id }));
 
-  const roll = rollup.createRollupFromArray(project, ...blocks);
+  const roll = rollupFromArray(project, ...blocks);
   return roll;
 };


### PR DESCRIPTION
- rollup utils in their own folder for creating new rollups
- sets up empty project for a new user
- update projectLoad to handle opening another project if it fails. update global nav deleting and project page opening projects