### PR TITLE
Projects querying with grep doesn't error

### DIFF
--- a/server/auth/userSetup.js
+++ b/server/auth/userSetup.js
@@ -31,14 +31,6 @@ const createInitialData = (user) => {
 
 const checkUserSetup = (user) => {
   return querying.listProjectsWithAccess(user.uuid)
-    //fixme - sometimes this fails if the user has no projects, so lets just make in that case
-    //should update listProjectsWIthAccess
-    .catch((err) => {
-      console.log('error querying for projets');
-      console.log(err);
-      console.log(err.stack);
-      return [];
-    })
     .then(projects => {
       if (!projects.length) {
         // create rollups return ID of empty project

--- a/test/server/data/querying.spec.js
+++ b/test/server/data/querying.spec.js
@@ -30,7 +30,7 @@ describe('Server', () => {
           metadata: { name: terminatorBlockName },
           rules: { role: 'terminator' },
         });
-        merge(roll.blocks, {[promoter.id]: promoter, [terminator.id]: terminator});
+        merge(roll.blocks, { [promoter.id]: promoter, [terminator.id]: terminator });
         roll.project.components.push(promoter.id, terminator.id);
         return roll;
       };
@@ -43,6 +43,8 @@ describe('Server', () => {
       const otherUserId = uuid.v4();
       const otherRolls = [1, 2, 3].map(createCustomRollup);
       const otherRollIds = otherRolls.map(roll => roll.project.id);
+
+      const randomUserId = uuid.v4();
 
       before(() => {
         return Promise.all([
@@ -69,6 +71,13 @@ describe('Server', () => {
           .then(projects => {
             expect(projects.length).to.equal(myRollIds.length);
             assert(projects.every(projectId => myRollIds.indexOf(projectId) >= 0), 'wrong project was returned..');
+          });
+      });
+
+      it('listProjectsWithAccess() doesnt fail when user has no projects', () => {
+        return querying.listProjectsWithAccess(randomUserId)
+          .then(projects => {
+            expect(projects.length).to.equal(0);
           });
       });
 


### PR DESCRIPTION
querying user projects uses spawn rather than exec, does not error when user has no projects. add a test

includes part of #590 (merge that first)