### PR TITLE
refresh page on sign out to ensure store data is cleared

### DIFF
--- a/src/components/authentication/userwidget.js
+++ b/src/components/authentication/userwidget.js
@@ -50,7 +50,9 @@ class UserWidget extends Component {
   signOut() {
     this.props.userLogout()
     .then(() => {
-      this.props.push('/homepage');
+      // store is left with previous user projects and other issue. For now do a complete reload
+      //this.props.push('/homepage');
+      window.location = `${window.location.protocol}\\\\${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}\\homepage`;
     })
     .catch((reason) => {
       this.props.uiSetGrunt('There was a problem signing you out');


### PR DESCRIPTION
App is lots of issues related to holding onto previous owners data when signing out as one persona then back in with a different one. This addresses by forcing a page reload on sign out.