### PR TITLE
force docker json-file logging

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -11,3 +11,4 @@ genome-designer:
     HOST_URL: http://genome-designer${AUTH_ENV_TAG}.bionano.autodesk.com
   command:
     npm run server-auth
+  log_driver: json-file


### PR DESCRIPTION
Our Docker Hosts are configured globally to use the Fluent Log Driver, which isn't currently working. This change will explicitly tell Docker to use the json-file format for logging when starting the application so that logs can be viewed locally on the machine.