### PR TITLE
Show hidden blocks on drag-drop

### DIFF
--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -31,7 +31,7 @@ import { pauseAction, resumeAction } from '../store/pausableStore';
 export const blockLoad = (blockId, inputProjectId, withContents = false, skipIfContentsEmpty = false) => {
   return (dispatch, getState) => {
     const retrieved = getState().blocks[blockId];
-    if (skipIfContentsEmpty === true && retrieved && !retrieved.components.length && !Object.keys(retrieved.options).length) {
+    if (skipIfContentsEmpty === true && retrieved && !retrieved.hasContents()) {
       return Promise.resolve([retrieved]);
     }
 

--- a/src/components/Inventory/InventoryRoleMap.js
+++ b/src/components/Inventory/InventoryRoleMap.js
@@ -114,7 +114,7 @@ export class InventoryRoleMap extends Component {
 
     const content = loadingMap ?
       <Spinner /> :
-      Object.keys(typeMap).map(type => {
+      Object.keys(typeMap).sort().map(type => {
         const count = typeMap[type];
         const name = symbolMap[type] || type;
         const items = loadedTypes[type] || [];

--- a/src/components/Inventory/InventoryRoleMap.js
+++ b/src/components/Inventory/InventoryRoleMap.js
@@ -105,7 +105,7 @@ export class InventoryRoleMap extends Component {
     //get components if its a construct and add blocks to the store
     //note - this may be a very large query
     return this.props.blockLoad(item.id, item.projectId, true, true)
-      .then(() => item);
+      .then(() => item.setRule('hidden', false));
   };
 
   render() {

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -86,6 +86,11 @@ export default class Block extends Instance {
    type checks
    ************/
 
+  //has components or list options
+  hasContents() {
+    return this.components.length || Object.keys(this.options).length;
+  }
+
   //isSpec() can't exist here, since dependent on children. use selector blockIsSpec instead.
 
   isConstruct() {


### PR DESCRIPTION
Includes #632 

Dragging in a hidden block makes it unhidden.
Alphabetize roles in role map of inventory.