### PR TITLE
Several annotation enhancements.

### DIFF
--- a/plugins/convert/genbank/genbank_export.py
+++ b/plugins/convert/genbank/genbank_export.py
@@ -76,16 +76,23 @@ def convert_annotations(block, gb):
     for annotation in block["sequence"]["annotations"]:
         gb_annot = SeqFeature.SeqFeature()
         annotation_type = "unknown"
+
+        if "role" in annotation and annotation["role"] != "":
+            annotation_type = annotation["role"]
+
         for key, value in annotation.iteritems():
-            if key not in ["start", "end", "notes", "strand"]:
+            if key not in ["start", "end", "notes", "strand", "color", "role"]:
                 gb_annot.qualifiers[key] = value
+            elif key == "color":
+                gb_annot.qualifiers["GC_Color"] = value
             elif key == "notes":
                 for notes_key, notes_value in annotation["notes"].iteritems():
                     if notes_key == "genbank":
                         for gb_key, gb_value in notes_value.iteritems():
-                            gb_annot.qualifiers[gb_key] = gb_value
-                    if notes_key == "type":
-                        annotation_type = notes_value
+                            if gb_key not in ["type"]:
+                                gb_annot.qualifiers[gb_key] = gb_value
+                            elif gb_key == "type":
+                                annotation_type = gb_value
 
         if "start" in annotation:
             strand = 1

--- a/plugins/convert/genbank/genbank_import.py
+++ b/plugins/convert/genbank/genbank_import.py
@@ -69,6 +69,9 @@ def convert_block_to_feature(all_blocks, to_convert, parent, to_remove_list):
         else:
             feature["notes"][key] = value
 
+    if "role" in to_convert["rules"]:
+        feature["role"] = to_convert["rules"]["role"]
+
     #feature["sequence"] = to_convert["sequence"]["sequence"]
 
     if "annotations" not in parent["sequence"]:

--- a/plugins/convert/genbank/index.js
+++ b/plugins/convert/genbank/index.js
@@ -4,10 +4,12 @@ import * as filePaths from '../../../server/utils/filePaths';
 import path from 'path';
 import Project from '../../../src/models/Project';
 import Block from '../../../src/models/Block';
+import Annotation from '../../../src/models/Annotation';
 import merge from 'lodash.merge';
 import _ from 'lodash';
 import BlockSchema from '../../../src/schemas/Block';
 import ProjectSchema from '../../../src/schemas/Project';
+import AnnotationSchema from '../../../src/schemas/Annotation';
 import * as persistence from '../../../server/data/persistence';
 import md5 from 'md5';
 
@@ -50,13 +52,21 @@ const createBlockStructureAndSaveSequence = (block, sourceId) => {
   //get the sequence md5
   const sequenceMd5 = block.sequence.sequence ? md5(block.sequence.sequence) : '';
 
+  // Remap annotations
+  let allAnnotations = [];
+  if (block.sequence.annotations) {
+    allAnnotations = block.sequence.annotations.map(ann => {
+      return Annotation.classless(merge({}, AnnotationSchema.scaffold(true), ann));
+    });
+  }
+
   //reassign values
   const toMerge = {
     metadata: block.metadata,
     sequence: {
       md5: sequenceMd5,
       length: block.sequence.length,
-      annotations: block.sequence.annotations, //you will likely have to remap these...
+      annotations: allAnnotations,
     },
     source: {
       id: fileName,

--- a/plugins/convert/import.js
+++ b/plugins/convert/import.js
@@ -9,6 +9,7 @@ import * as filePaths from '../../server/utils/filePaths';
 import { errorDoesNotExist } from '../../server/utils/errors';
 import md5 from 'md5';
 import { merge, filter } from 'lodash';
+import resetColorSeed from '../../src/utils/generators/color';
 
 const router = express.Router(); //eslint-disable-line new-cap
 const jsonParser = bodyParser.json({
@@ -75,6 +76,7 @@ router.post('/:pluginId/convert', jsonParser, (req, resp, next) => {
 
   req.on('end', () => {
     const inputFilePath = filePaths.createStorageUrl(pluginId, md5(buffer));
+    resetColorSeed();
     return fileSystem.fileWrite(inputFilePath, buffer, false)
       .then(() => callImportFunction('convert', pluginId, inputFilePath))
       .then(converted => {
@@ -102,6 +104,7 @@ router.post('/:pluginId/:projectId?', jsonParser, (req, resp, next) => {
         const inputFilePath = filePaths.createStorageUrl(pluginId, md5(data));
         fileSystem.fileWrite(inputFilePath, data, false)
           .then((err) => {
+            resetColorSeed();
             return importProject(pluginId, inputFilePath)
               .then((roll) => {
                 if (!projectId) {

--- a/src/models/Annotation.js
+++ b/src/models/Annotation.js
@@ -22,7 +22,7 @@ import { symbolMap } from '../inventory/roles';
 
 export default class Annotation extends Instance {
   constructor(input) {
-    super(input, AnnotationSchema.scaffold(), { metadata: { color: color() } });
+    super(input, AnnotationSchema.scaffold(), { color: color() });
   }
 
   //return an unfrozen JSON (

--- a/src/models/Annotation.js
+++ b/src/models/Annotation.js
@@ -13,14 +13,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import Instance from './Instance';
-import invariant from 'invariant';
+import Immutable from './Immutable';
 import AnnotationSchema from '../schemas/Annotation';
 import cloneDeep from 'lodash.clonedeep';
 import color from '../utils/generators/color';
 import { symbolMap } from '../inventory/roles';
 
-export default class Annotation extends Instance {
+export default class Annotation extends Immutable {
   constructor(input) {
     super(input, AnnotationSchema.scaffold(), { color: color() });
   }

--- a/src/models/Annotation.js
+++ b/src/models/Annotation.js
@@ -15,13 +15,17 @@
  */
 import Immutable from './Immutable';
 import AnnotationSchema from '../schemas/Annotation';
-import cloneDeep from 'lodash.clonedeep';
+import { merge, cloneDeep } from 'lodash';
 import color from '../utils/generators/color';
 import { symbolMap } from '../inventory/roles';
 
 export default class Annotation extends Immutable {
   constructor(input) {
-    super(input, AnnotationSchema.scaffold(), { color: color() });
+    return super(merge(
+      AnnotationSchema.scaffold(),
+      { color: color() },
+      input,
+    ));
   }
 
   //return an unfrozen JSON (

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -1,18 +1,18 @@
 /*
-Copyright 2016 Autodesk,Inc.
+ Copyright 2016 Autodesk,Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 import Instance from './Instance';
 import invariant from 'invariant';
 import { merge, cloneDeep } from 'lodash';
@@ -54,10 +54,11 @@ export default class Block extends Instance {
   clone(parentInfo = {}, overwrites = {}) {
     const [ firstParent ] = this.parents;
 
-    //unfreeze a clone by default, but allow overwriting if really want to
-    const mergeWith = merge({
-      rules: { frozen: false },
-    }, overwrites);
+    //unfreeze a clone by default if it is frozen, but allow overwriting if really want to
+    //don't want to add the field if unnecessary
+    const mergeWith = this.rules.frozen === true ?
+      merge({ rules: { frozen: false } }, overwrites) :
+      overwrites;
 
     if (parentInfo === null) {
       return super.clone(false, mergeWith);

--- a/src/models/Immutable.js
+++ b/src/models/Immutable.js
@@ -1,0 +1,56 @@
+/*
+ Copyright 2016 Autodesk,Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+import { set as pathSet, unset as pathUnset, cloneDeep, merge } from 'lodash';
+import invariant from 'invariant';
+
+/**
+ * @description
+ * you can pass as argument to the constructor either:
+ *  - an object, which will extend the created instance
+ */
+export default class Immutable {
+  constructor(input = {}) {
+    invariant(typeof input === 'object', 'must pass an object Immutable constructor');
+
+    merge(this,
+      input,
+    );
+
+    if (process.env.NODE_ENV !== 'production') {
+      require('deep-freeze')(this);
+    }
+
+    return this;
+  }
+
+  //use cloneDeep and perform mutation prior to calling constructor because constructor may freeze object
+
+  // returns a new instance
+  // uses lodash _.set() for path, e.g. 'a.b[0].c'
+  mutate(path, value) {
+    const base = cloneDeep(this);
+    pathSet(base, path, value);
+    return new this.constructor(base);
+  }
+
+  // returns a new instance
+  // deep merge using _.merge
+  merge(obj) {
+    const base = cloneDeep(this);
+    merge(base, obj);
+    return new this.constructor(base);
+  }
+}

--- a/src/models/Instance.js
+++ b/src/models/Instance.js
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import uuid from 'node-uuid';
 import { set as pathSet, unset as pathUnset, cloneDeep, merge } from 'lodash';
 import invariant from 'invariant';
+import Immutable from './Immutable';
 import InstanceSchema from '../schemas/Instance';
 import safeValidate from '../schemas/fields/safeValidate';
 import { version } from '../schemas/fields/validators';
@@ -27,20 +27,16 @@ const versionValidator = (ver, required = false) => safeValidate(version(), requ
  * you can pass as argument to the constructor either:
  *  - an object, which will extend the created instance
  */
-export default class Instance {
+export default class Instance extends Immutable {
   constructor(input = {}, subclassBase, moreFields) {
     invariant(typeof input === 'object', 'must pass an object (or leave undefined) to model constructor');
 
-    merge(this,
+    return super(merge(
       InstanceSchema.scaffold(),
       subclassBase,
       moreFields,
       input,
-    );
-
-    if (process.env.NODE_ENV !== 'production') {
-      require('deep-freeze')(this);
-    }
+    ));
   }
 
   //use cloneDeep and perform mutation prior to calling constructor because constructor may freeze object

--- a/src/schemas/Annotation.js
+++ b/src/schemas/Annotation.js
@@ -42,6 +42,10 @@ const fieldDefs = {
     fields.string(),
     'Description of annotation',
   ],
+  color: [
+    fields.string(),
+    `Color of the Annotation`,
+  ],
   role: [
     fields.string(),
     `Role of the Annotation`,

--- a/src/utils/generators/color.js
+++ b/src/utils/generators/color.js
@@ -44,3 +44,7 @@ export default function color() {
 export function randomColor() {
   return '#' + Math.floor(Math.random() * Math.pow(2, 24)).toString(16);
 }
+
+export function resetColorSeed() {
+  lastIndex = 0;
+}

--- a/test/models/Annotation.js
+++ b/test/models/Annotation.js
@@ -1,0 +1,17 @@
+import { expect, assert } from 'chai';
+import Annotation from '../../src/models/Annotation';
+import AnnotationSchema from '../../src/schemas/Annotation';
+import merge from 'lodash.merge';
+
+describe('Model', () => {
+  describe.only('Annotation', () => {
+    let annotation;
+    beforeEach(() => {
+      annotation = new Annotation();
+    });
+
+    it('should have a default color', () => {
+      assert(annotation.color, 'should have a color');
+    });
+  });
+});

--- a/test/models/Instance.spec.js
+++ b/test/models/Instance.spec.js
@@ -1,4 +1,5 @@
 import Instance from '../../src/models/Instance';
+import InstanceSchema from '../../src/schemas/Instance';
 import chai from 'chai';
 import sha1 from 'sha1';
 
@@ -11,6 +12,16 @@ describe('Model', () => {
         const inst = new Instance();
 
         expect(inst.constructor).to.be.a('function');
+      });
+
+      it('should include scaffold for default input', () => {
+        const inst = new Instance();
+        const scaffold = InstanceSchema.scaffold();
+        const massaged = Object.assign({}, scaffold, {
+          id: inst.id,
+        });
+        expect(inst).to.eql(massaged);
+        assert(typeof inst.metadata === 'object', 'should have metadata field');
       });
 
       it('should accept existing input', () => {


### PR DESCRIPTION
All genbank imports start from the same color now.
Annotations have roles.
Annotations have colors (automatically assigned), and they roundtrip them through Genbank.
Flattened out the color attribute for the annotation. It's on the main structure, not in the metadata.