### PR TITLE
pass NODE_ENV into docker image when set by Jenkins

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -9,6 +9,7 @@ genome-designer:
     STORAGE: /projects
     API_END_POINT: http://auth${AUTH_ENV_TAG}.bionano.bio:8080/api
     HOST_URL: http://genome-designer${AUTH_ENV_TAG}.bionano.autodesk.com
+    NODE_ENV: ${NODE_ENV}
   command:
     npm run server-auth
   log_driver: json-file


### PR DESCRIPTION
Jenkins will tell CloudFormation to inject NODE_ENV into the docker-compose process, which will then inject the NODE_ENV into the docker image that runs the node process.