### PR TITLE
update HOST_URL envs to fix password reset emails

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -8,7 +8,7 @@ genome-designer:
   environment:
     STORAGE: /projects
     API_END_POINT: http://auth${BNR_ENV_URL_SUFFIX}.bionano.bio:8080/api
-    HOST_URL: https://geneticconstructor${BNR_ENV_URL_SUFFIX}.bionano.autodesk.com
+    HOST_URL: https://geneticconstructor.bionano.autodesk.com
   command:
     npm run server-auth
   log_driver: json-file


### PR DESCRIPTION
This change fixes the HOST_URL environment variable in all environments so that email verify and password reset emails work and contain secure links.

When this change is merged into production, a change to the Jenkins production deployment job needs to be made.