### PR TITLE
add script for starting up auth + storage platform in spawned processes

### DIFF
--- a/docs/installation-bio-user-platform.md
+++ b/docs/installation-bio-user-platform.md
@@ -1,0 +1,81 @@
+## bio-user-platform
+
+**Installing the bio-user-platform requires access to the private Autodesk GitHub.**
+
+After setting up the user auth platform locally, authentication can be enabled by setting the `BIO_NANO_AUTH`
+environment variable to `1` or by using the `auth-test` npm target.
+
+```
+npm run auth
+```
+
+Running this command will attempt to access `git.autodesk.com`. [gotcha][]
+
+#### manual user authentication setup
+
+If you want to use/test user authentication locally, do the following:
+
+1) clone the Bio/Nano User Platform repo locally.
+
+```
+git clone https://git.autodesk.com/bionano/bio-user-platform.git ~/src/bio-user-platform
+cd ~/src/bio-user-platform
+git checkout genome-designer
+```
+
+2) Install Docker (Don't use brew, go [here](https://docs.docker.com/engine/installation/mac/).)
+
+3) Install Bio/Nano User Platform dependencies
+
+```
+cd ~/src/bio-user-platform
+npm install
+```
+
+4) Start the Authentication Service locally. Choose method:
+    1) Docker storage and Docker node
+    2) Docker storage + local node (easier debugging)
+
+```
+# Method i
+# cd ~/src/bio-user-platform
+eval "$(docker-machine env default)"
+docker-compose up
+```
+
+```
+# Method ii
+# in one terminal:
+cd ~/src/bio-user-platform
+bash /Applications/Docker/Docker\ Quickstart\ Terminal.app/Contents/Resources/Scripts/start.sh
+eval "$(docker-machine env default)"
+npm run storage
+#
+#in another terminal:
+cd ~/src/bio-user-platform
+npm start
+```
+
+5) Start the Genome Designer Application
+
+If you've chosen `method ii` above, you start the Genome Designer normally with `npm run auth`
+
+If you've chosen `method i` above, you need to tell the Genome Designer application to look for the Auth Service on
+your docker host.
+
+```
+API_END_POINT="http://$(docker-machine ip default):8080/api" npm run auth
+```
+
+#### user authentication tests
+
+Currently authentication tests in `test/server/auth/REST.spec.js` require access to an Authentication Server.
+
+#### npm install from git.autodesk.com authentication fails [gotcha] ####
+
+Currently npm won't prompt for username and password when attempting to install a package from a private GitHub
+repository. So, if you haven't saved credentials for `git.autodesk.com` into your git credential cache, running
+`npm run auth` or `npm run auth-test` will fail when it tries to pull the authentication package from `git.autodesk.com`.
+The easiest way to save git credentials is to clone a repository. Instructions for setting up credential caching
+can be found [here](https://help.github.com/articles/caching-your-github-password-in-git/).
+FYI: After installing you will still need to set your credentials...try something like: 'git clone https://git.autodesk.com/bionano/bio-user-platform.git temp' to force git prompt you for them

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,82 +12,10 @@ Please check `package.json` to ensure you have valid versions of globally instal
 
 ## With Authentication
 
-User authentication depends on the Bio/Nano User Platform project, which is currently not open source. As a result user
-authentication is NOT enabled by default when running this application locally. Authentication routes and a user object
-is provided but is mocked in middleware and routes provided in this project by default.
+User authentication depends on the Bio/Nano User Platform project, which is currently not open source and requires access to the Autodesk internal GitHub.
 
-After setting up the user auth platform locally, authentication can be enabled by setting the `BIO_NANO_AUTH`
-environment variable to `1` or by using the `auth-test` npm target.
+As a result, user authentication is NOT enabled by default when running this application locally. Authentication routes and a user object is provided but is mocked in middleware and routes provided in this project by default.
 
-```
-npm run auth
-```
+If you have the bio-user-platform installed, you can run the server with authentication by running `npm run start-auth-stack`.
 
-Running this command will attempt to access `git.autodesk.com`. [gotcha][]
-
-#### manual user authentication setup
-If you want to use/test user authentication locally, do the following:
-
-1) clone the Bio/Nano User Platform repo locally.
-
-```
-git clone https://git.autodesk.com/bionano/bio-user-platform.git ~/src/bio-user-platform
-cd ~/src/bio-user-platform
-git checkout genome-designer
-```
-
-2) Install Docker (Don't use brew, go [here](https://docs.docker.com/engine/installation/mac/).)
-3) Install Bio/Nano User Platform dependencies
-
-```
-cd ~/src/bio-user-platform
-npm install
-```
-
-4) Start the Authentication Service locally. Choose method:
-    1) Docker storage and Docker node
-    2) Docker storage + local node (easier debugging)
-
-```
-# Method i
-# cd ~/src/bio-user-platform
-eval "$(docker-machine env default)"
-docker-compose up
-```
-
-```
-# Method ii
-# in one terminal:
-cd ~/src/bio-user-platform
-bash /Applications/Docker/Docker\ Quickstart\ Terminal.app/Contents/Resources/Scripts/start.sh
-eval "$(docker-machine env default)"
-npm run storage
-#
-#in another terminal:
-cd ~/src/bio-user-platform
-npm start
-```
-
-5) Start the Genome Designer Application
-
-If you've chosen `method ii` above, you start the Genome Designer normally with `npm run auth`
-
-If you've chosen `method i` above, you need to tell the Genome Designer application to look for the Auth Service on
-your docker host.
-
-```
-API_END_POINT="http://$(docker-machine ip default):8080/api" npm run auth
-```
-
-#### user authentication tests
-
-Currently authentication tests in `test/server/auth/REST.spec.js` require access to an Authentication Server.
-
-#### npm install from git.autodesk.com authentication fails [gotcha] ####
-
-Currently npm won't prompt for username and password when attempting to install a package from a private GitHub
-repository. So, if you haven't saved credentials for `git.autodesk.com` into your git credential cache, running
-`npm run auth` or `npm run auth-test` will fail when it tries to pull the authentication package from `git.autodesk.com`.
-The easiest way to save git credentials is to clone a repository. Instructions for setting up credential caching
-can be found [here](https://help.github.com/articles/caching-your-github-password-in-git/).
-FYI: After installing you will still need to set your credentials...try something like: 'git clone https://git.autodesk.com/bionano/bio-user-platform.git temp' to force git prompt you for them
+[Click here to read how to install the bio-user-platform](docs/installation-bio-user-platform.md)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "babel-node tools/run start",
     "start-instance": "babel-node tools/run start-instance",
+    "start-auth-stack": "babel-node tools/run auth",
     "clean": "babel-node tools/run clean",
     "build": "babel-node tools/run build",
     "build-client": "babel-node tools/run bundle",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "babel-node tools/run start",
     "start-instance": "babel-node tools/run start-instance",
-    "start-auth-stack": "babel-node tools/run auth",
+    "start-auth-stack": "babel-node tools/run auth-stack",
     "clean": "babel-node tools/run clean",
     "build": "babel-node tools/run build",
     "build-client": "babel-node tools/run bundle",

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,11 +15,37 @@ TODO: Build the server. Not building because of relative path issues, in particu
 
 ## Build Automation Tools
 
+### Command line flags
+
+All scripts in this section can be
+
+Flag          | Description
+------------- | --------------------------------------------------
+`--release`   | Minimizes and optimizes the compiled output
+`--verbose`   | Prints detailed information to the console
+`--debugmode` | Launches the App in Debugging mode (e.g. with Redux devtools)
+
+An additional `--` before flags is necessary to pass the arguments from babel-node to the actual process spawned (see examples).
+
 #### `npm run start` (`start.js`)
 
 * Cleans up the output `/build` directory (`clean.js`)
 * Copies static files to the output folder (`copy.js`)
 * Launches [Webpack](https://webpack.github.io/) compiler in a watch mode, and runs the server in a Browser Sync Proxy
+
+##### Examples
+
+Run the app for local development, with full sourcemapping etc.
+
+```sh
+$ npm run start
+```
+
+Launch dev server in production mode + minified
+
+```sh
+$ npm start -- --release
+```
 
 #### `npm run build` (`build.js`)
 
@@ -27,29 +53,25 @@ TODO: Build the server. Not building because of relative path issues, in particu
 * Copies static files to the output folder (`copy.js`)
 * Creates application bundles with Webpack (`bundle.js`, `webpack.config.js`)
 
-#### Options
+##### Examples
 
-Flag          | Description
-------------- | -------------------------------------------------- 
-`--release`   | Minimizes and optimizes the compiled output
-`--verbose`   | Prints detailed information to the console
-`--debugmode` | Launches the App in Debugging mode (e.g. with Redux devtools)
-
-For example:
+Build the app in production mode and log each step
 
 ```sh
-$ npm run start     # Run the app for local development, with full sourcemapping etc.
+$ npm run build -- --release --verbose
 ```
+
+#### `npm run start-instance` (`start-instance.js`)
+
+* clean, setup
+* Bundle the client, and save it to the file system
+* Run the server (using babel-node) without webpack middleware or file watchers
+
+##### Examples
 
 ```sh
-$ npm start -- --release        # Launch dev server in production mode + minified
+$ npm run start-instance
 ```
-
-```sh
-$ npm run build -- --release --verbose   # Build the app in production mode
-```
-
-The additional `--` before flags is necessary to pass the arguments from babel-node to the actual process spawned.
 
 #### `npm run start-auth-stack` (`auth-stack.js`)
 
@@ -61,20 +83,24 @@ The additional `--` before flags is necessary to pass the arguments from babel-n
     * Storage
 * start server with authentication (`npm run auth`)
 
-###### Options
+##### Additional Options
 
 Flag                                           | Description
 ---------------------------------------------- | --------------------------------------------------
 `--PLATFORM_PATH=/path/to/bio-user-platform/`  | Define path to bio-user-platform, defaults to sibling with project root
 `--DEBUG`                                      | Log all output
 
-##### Example
+##### Examples
+
+Run using babel-node directly, and pass in a flag
 
 ```sh
-$ babel-node tools/run auth-stack -- --DEBUG # Run using babel-node directly, and pass in a flag
+$ babel-node tools/run auth-stack -- --DEBUG
 ```
 
-#### Misc
+## Misc
+
+#### Files
 
 * `webpack.config.js` - Webpack configuration for both client-side and server-side bundles
 * `run.js` - Helps to launch other scripts with `babel-node` (e.g. `babel-node tools/run build`)

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,19 +15,19 @@ TODO: Build the server. Not building because of relative path issues, in particu
 
 ## Build Automation Tools
 
-##### `npm run start` (`start.js`)
+#### `npm run start` (`start.js`)
 
 * Cleans up the output `/build` directory (`clean.js`)
 * Copies static files to the output folder (`copy.js`)
 * Launches [Webpack](https://webpack.github.io/) compiler in a watch mode, and runs the server in a Browser Sync Proxy
 
-##### `npm run build` (`build.js`)
+#### `npm run build` (`build.js`)
 
 * Cleans up the output `/build` folder (`clean.js`)
 * Copies static files to the output folder (`copy.js`)
 * Creates application bundles with Webpack (`bundle.js`, `webpack.config.js`)
 
-##### Options
+#### Options
 
 Flag          | Description
 ------------- | -------------------------------------------------- 
@@ -50,6 +50,29 @@ $ npm run build -- --release --verbose   # Build the app in production mode
 ```
 
 The additional `--` before flags is necessary to pass the arguments from babel-node to the actual process spawned.
+
+#### `npm run start-auth-stack` (`auth-stack.js`)
+
+**Requires local install of `bio-user-platform`**
+
+* Starts Docker
+* Starts bio-user-platform
+    * Authentication
+    * Storage
+* start server with authentication (`npm run auth`)
+
+###### Options
+
+Flag                                           | Description
+---------------------------------------------- | --------------------------------------------------
+`--PLATFORM_PATH=/path/to/bio-user-platform/`  | Define path to bio-user-platform, defaults to sibling with project root
+`--DEBUG`                                      | Log all output
+
+##### Example
+
+```sh
+$ babel-node tools/run auth-stack -- --DEBUG # Run using babel-node directly, and pass in a flag
+```
 
 #### Misc
 

--- a/tools/auth-stack.js
+++ b/tools/auth-stack.js
@@ -27,13 +27,13 @@ console.log('path for bio-user-platform is ' + pathBioNanoPlatform + '. Set by p
 /** command utils **/
 
 //simple wrap around console.log
-const log = (output, forceOutput) => {
+const log = (output, forceOutput = false) => {
   if (DEBUG || forceOutput === true) {
     console.log(output);
   }
 };
 
-const promisedExec = (cmd, opts) => {
+const promisedExec = (cmd, opts, forceOutput) => {
   console.log('running ' + cmd);
 
   return new Promise((resolve, reject) => {
@@ -42,15 +42,17 @@ const promisedExec = (cmd, opts) => {
         console.error(err);
         return reject(err);
       }
-      //convert from buffers
-      log(`${stdout}
-${stderr}`);
+
+      //`` to convert from buffers
+      log(`${stdout}`, forceOutput);
+      log(`${stderr}`, forceOutput);
+
       return resolve(`${stdout}`, `${stderr}`);
     });
   });
 };
 
-const spawnWaitUntilString = (cmd, args, opts, waitUntil, forceOutput = false) => {
+const spawnWaitUntilString = (cmd, args, opts, waitUntil, forceOutput) => {
   console.log('running: ' + cmd + ' ' + args.join(' '));
 
   return new Promise((resolve, reject) => {
@@ -58,14 +60,14 @@ const spawnWaitUntilString = (cmd, args, opts, waitUntil, forceOutput = false) =
     const process = spawn(cmd, args, opts);
 
     process.stdout.on('data', data => {
-      log(`${data}`);
+      log(`${data}`, forceOutput);
       if (`${data}`.indexOf(waitUntil) >= 0) {
         resolve(process);
       }
     });
 
     process.stderr.on('data', data => {
-      log(`${data}`);
+      log(`${data}`, forceOutput);
       if (`${data}`.indexOf(waitUntil) >= 0) {
         resolve(process);
       }
@@ -77,7 +79,7 @@ const spawnWaitUntilString = (cmd, args, opts, waitUntil, forceOutput = false) =
     });
 
     process.on('close', (code) => {
-      log(`child process exited with code ${code}`);
+      log(`child process exited with code ${code}`, forceOutput);
     });
   });
 };

--- a/tools/auth.js
+++ b/tools/auth.js
@@ -1,0 +1,139 @@
+import { exec, spawn } from 'child_process';
+import path from 'path';
+
+/** paths **/
+
+const pathProjectRoot = path.resolve(__dirname, '../');
+let pathBioNanoPlatform = path.resolve(pathProjectRoot, '../bio-user-platform');
+
+//if this isnt working, you can debug with --DEBUG flag
+const DEBUG = process.argv.includes('--DEBUG');
+if (!DEBUG) {
+  console.log('debug auth startup by passing --DEBUG');
+}
+
+//allow overwriting the bio-user-platform path
+process.argv.forEach((val, index) => {
+  const argFlag = 'PLATFORM_PATH';
+  if (val.startsWith(argFlag)) {
+    const newPath = val.substr(argFlag.length + 1);
+    pathBioNanoPlatform = newPath;
+  }
+});
+console.log('path for bio-user-platform is ' + pathBioNanoPlatform + '. Set by passing --PLATFORM_PATH=/your/path');
+
+const log = (...args) => {
+  if (DEBUG) {
+    console.log.apply(console, args);
+  }
+};
+
+/** command utils **/
+
+const promisedExec = (cmd, opts) => {
+  console.log('running ' + cmd);
+
+  return new Promise((resolve, reject) => {
+    exec(cmd, opts, (err, stdout, stderr) => {
+      if (err) {
+        console.error(err);
+        return reject(err);
+      }
+      //convert from buffers
+      log(`${stdout}
+${stderr}`);
+      return resolve(`${stdout}`, `${stderr}`);
+    });
+  });
+};
+
+const spawnWaitUntilString = (cmd, args, opts, waitUntil) => {
+  console.log('running: ' + cmd + ' ' + args.join(' '));
+
+  return new Promise((resolve, reject) => {
+    //const [ command, ...args ] = cmd.split(' ');
+    const process = spawn(cmd, args, opts);
+
+    process.stdout.on('data', data => {
+      log(`${data}`);
+      if (`${data}`.indexOf(waitUntil) >= 0) {
+        resolve(process);
+      }
+    });
+
+    process.stderr.on('data', data => {
+      log(`${data}`);
+      if (`${data}`.indexOf(waitUntil) >= 0) {
+        resolve(process);
+      }
+    });
+
+    process.on('error', (err) => {
+      console.log('Error in process');
+      console.log(err);
+    });
+
+    process.on('close', (code) => {
+      log(`child process exited with code ${code}`);
+    });
+  });
+};
+
+/** scripts **/
+
+let dockerEnv;
+
+const setupBioNanoPlatform = () => {
+  return promisedExec(`git checkout genome-designer`, {
+    cwd: pathBioNanoPlatform,
+  })
+    .then(() => promisedExec(`npm install`, {
+      cwd: pathBioNanoPlatform,
+    }));
+};
+
+const startBioNanoPlatform = () => {
+  return spawnWaitUntilString('bash', ['/Applications/Docker/Docker\ Quickstart\ Terminal.app/Contents/Resources/Scripts/start.sh'], {
+    cwd: pathBioNanoPlatform,
+  }, 'For help getting started,')
+    .then(() => promisedExec(`docker-machine env default --shell=bash`, {
+      cwd: pathBioNanoPlatform,
+    }))
+    .then((stdout, stderr) => {
+      //manually handle docker-machine ENV and insert it, since spawn chaining commands complains
+      dockerEnv = stdout.split('\n')
+        .slice(0, 4)
+        .map(line => line.substr(7))
+        .map(line => line.replace(/\"/g, ''))
+        .reduce((acc, line) => {
+          const [ key, value ] = line.split('=');
+          return Object.assign(acc, { [key]: value });
+        }, {});
+
+      return spawnWaitUntilString('npm', ['run', 'storage-background'], {
+        cwd: pathBioNanoPlatform,
+        env: Object.assign({}, process.env, dockerEnv),
+      }, 'LOG:  database system is ready to accept connections');
+    });
+};
+
+const startAuthServer = () => {
+  return spawnWaitUntilString('npm', ['start'], {
+    cwd: pathBioNanoPlatform,
+  }, `{ address: { address: '::', family: 'IPv6', port: 8080 } } 'started'`);
+};
+
+const startRunAuth = () => {
+  return spawnWaitUntilString('npm', ['run', 'auth'], {
+    cwd: pathProjectRoot,
+  }, 'Server listening at http://0.0.0.0:3000/');
+};
+
+async function auth() {
+  await setupBioNanoPlatform();
+  await startBioNanoPlatform();
+  await startAuthServer();
+  await startRunAuth();
+}
+
+export default auth;

--- a/tools/auth.js
+++ b/tools/auth.js
@@ -6,6 +6,8 @@ import path from 'path';
 const pathProjectRoot = path.resolve(__dirname, '../');
 let pathBioNanoPlatform = path.resolve(pathProjectRoot, '../bio-user-platform');
 
+/** config **/
+
 //if this isnt working, you can debug with --DEBUG flag
 const DEBUG = process.argv.includes('--DEBUG');
 if (!DEBUG) {
@@ -22,13 +24,14 @@ process.argv.forEach((val, index) => {
 });
 console.log('path for bio-user-platform is ' + pathBioNanoPlatform + '. Set by passing --PLATFORM_PATH=/your/path');
 
-const log = (...args) => {
-  if (DEBUG) {
-    console.log.apply(console, args);
+/** command utils **/
+
+//simple wrap around console.log
+const log = (output, forceOutput) => {
+  if (DEBUG || forceOutput === true) {
+    console.log(output);
   }
 };
-
-/** command utils **/
 
 const promisedExec = (cmd, opts) => {
   console.log('running ' + cmd);
@@ -47,7 +50,7 @@ ${stderr}`);
   });
 };
 
-const spawnWaitUntilString = (cmd, args, opts, waitUntil) => {
+const spawnWaitUntilString = (cmd, args, opts, waitUntil, forceOutput = false) => {
   console.log('running: ' + cmd + ' ' + args.join(' '));
 
   return new Promise((resolve, reject) => {
@@ -126,7 +129,7 @@ const startAuthServer = () => {
 const startRunAuth = () => {
   return spawnWaitUntilString('npm', ['run', 'auth'], {
     cwd: pathProjectRoot,
-  }, 'Server listening at http://0.0.0.0:3000/');
+  }, 'Server listening at http://0.0.0.0:3000/', true);
 };
 
 async function auth() {


### PR DESCRIPTION
TODO 
- [x] add script storage-background to bio-user-platform (https://git.autodesk.com/bionano/bio-user-platform/pull/5)

----

`npm run start-auth-stack`

you can pass `--PLATFORM_PATH=/path/to/bio-user-platform/` if its not sibling with genetic-constructor (i.e. also in one directory below GC project root)

can pass `--DEBUG` to log output from all processes