### PR TITLE
Block.clone fix - dont reset IDs

### DIFF
--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -102,7 +102,7 @@ export default class Block extends Instance {
       overwrites;
 
     if (parentInfo === null) {
-      return super.clone(false, mergeWith);
+      return super.clone(parentInfo, mergeWith);
     }
 
     const parentObject = Object.assign({

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -88,7 +88,7 @@ export default class Block extends Instance {
    * Calls {@link Instance.clone} internally, but structure of block history is different than that of the Instance class.
    * Cloning a block will disable the frozen rule.
    * note that if you are cloning multiple blocks / blocks with components, you likely need to clone the components as well. You will need to re-map the IDs outside of this function. See {@link blockClone} action for an example.
-   * @param {object|null} parentInfo Parent info for denoting ancestry. If pass null to parentInfo, the Block is simply cloned, and nothing is added to the history.
+   * @param {object|null} parentInfo Parent info for denoting ancestry. If pass null to parentInfo, the Block is cloned without adding anything to the history, and it is unfrozen (and keeps the same ID).
    * @param overwrites
    * @returns {Block} Cloned block
    */

--- a/src/schemas/Block.js
+++ b/src/schemas/Block.js
@@ -37,6 +37,7 @@ const blockFields = {
     'Block UUID',
   ],
 
+  //todo - scaffold this to null to mark unassociated? and require the field?
   projectId: [
     fields.id({ prefix: 'project' }),
     'Project UUID',

--- a/src/selectors/blocks.js
+++ b/src/selectors/blocks.js
@@ -456,8 +456,10 @@ export const blockFlattenConstructAndLists = (blockId) => {
       const preference = optionPreferences[block.id];
       return (block.isList() && options.length) ?
         //give the block a color if in a list - technically the block in the store but all immutable so whatever
-        //hack - clone it because technically frozen
-        state.blocks[preference || options[0]].clone(false).merge({ metadata: { color: block.metadata.color } }) :
+        //clone it because technically frozen
+        state.blocks[preference || options[0]]
+          .clone(null)
+          .merge({ metadata: { color: block.metadata.color } }) :
         block;
     });
   };

--- a/test/models/Instance.spec.js
+++ b/test/models/Instance.spec.js
@@ -113,5 +113,13 @@ describe('Model', () => {
       expect(inst.clone.bind(inst, badVersion)).to.throw();
       expect(inst.clone.bind(inst, goodVersion)).to.not.throw();
     });
+
+    it('clone(null) does not change ID or add to history', () => {
+      const inst = new Instance();
+      const clone = inst.clone(null);
+      assert(clone !== inst, 'should not be the same instance');
+      assert(clone.id === inst.id, 'should have same id after clone(null)');
+      assert(clone.parents.length === inst.parents.length, 'should not add a parent');
+    });
   });
 });

--- a/test/store/autosaving.js
+++ b/test/store/autosaving.js
@@ -19,9 +19,11 @@ describe('Store', () => {
       }
     };
 
+    const throttleTime = 30;
+    const waitTime = 13;
+    assert(throttleTime > waitTime * 2, 'wait time must be less than throttle time');
+
     const saveSpy = sinon.spy();
-    const throttleTime = 500;
-    const waitTime = 250;
     const forceSaveActionType = 'FORCE_SAVE';
     const autosaving = autosaveCreator({
       time: throttleTime,
@@ -119,8 +121,8 @@ describe('Store', () => {
 
     it('coordinates across multiple reducers', (done) => {
       const coordinatingSpy = sinon.spy();
-      const savingTime = 500;
-      const waitingTime = 200;
+      const savingTime = 50;
+      const waitingTime = 20;
       const autosave = autosaveCreator({
         onSave: coordinatingSpy,
         time: savingTime,


### PR DESCRIPTION
e.g. on blockFlattenConstructAndLists()

also, speed up autosaving tests