### PR TITLE
do not change focus of option elements

### DIFF
--- a/src/containers/graphics/mousetrap.js
+++ b/src/containers/graphics/mousetrap.js
@@ -98,6 +98,12 @@ export default class MouseTrap {
    * mouse down handler, invoked on our target element
    */
   onMouseDown(event) {
+    // whenever our element gets a mouse down ( any button ) ensure any inputs are unfocused
+    if (document.activeElement
+      && document.activeElement.tagName
+      && (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA' )) {
+      document.activeElement.blur();
+    }
     // left button only
     if (event.which !== 1) {
       return;

--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -204,8 +204,11 @@ export default class Layout {
           listParentNode: parentNode,
         });
     } else {
-      // update all the list items
-      let focusedOptionRendered = false;
+      // find the index of the focused list option, or default the first one
+      let focusedIndex = enabled.findIndex(blockId => focusedOptionId === blockId);
+      if (focusedIndex < 0) {
+        focusedIndex = 0;
+      }
       enabled.forEach((blockId, index) => {
         // ensure we have a hash of list nodes for this block.
         let nodes = this.listNodes[block.id];
@@ -231,18 +234,9 @@ export default class Layout {
           listParentBlock: block,
           listParentNode: this.nodeFromElement(block.id),
           listBlock,
-          optionSelected: focusedOptionId === blockId,
+          optionSelected: index === focusedIndex,
         });
-        if (focusedOptionId === blockId) {
-          focusedOptionRendered = true;
-        }
       });
-      // if the enabled set of options does not contain the focused option
-      // then focus the first option. This will cause a re-render and would be
-      // better performed in the data store but here will do for now.
-      if (!focusedOptionRendered) {
-        this.constructViewer.optionSelected(block.id, enabled[0])
-      }
     }
   }
 


### PR DESCRIPTION
If the focused option is not present in a list block, default to showing the first one as select but DO NOT actually change the focus.

Note - this should speed up project loading significantly

When mousetrap module gets any mouse down event, blur and textarea or input with the focus.