### PR TITLE
create projects on register in sequence, so return empty project

### DIFF
--- a/server/auth/userSetup.js
+++ b/server/auth/userSetup.js
@@ -24,7 +24,7 @@ This file creates starting content for users
 NOTE - create instances using Block.classless and Project.classless - the server is expect JSON blobs that it can assign to, and instances of classes are frozen.
  */
 
-//create the EGF project for them
+//create the EGF project + empty project for them
 const createInitialData = (user) => {
   const egfRollup = makeEgfRollup();
   console.log('[EGF ROLLUP] made rollup ' + egfRollup.project.id + ' for user ' + user.uuid);
@@ -32,10 +32,8 @@ const createInitialData = (user) => {
 
   const emptyProjectRollup = rollupWithConstruct(true);
 
-  return Promise.all([
-    rollup.writeProjectRollup(emptyProjectRollup.project.id, emptyProjectRollup, user.uuid),
-    rollup.writeProjectRollup(egfRollup.project.id, egfRollup, user.uuid),
-  ]);
+  return rollup.writeProjectRollup(egfRollup.project.id, egfRollup, user.uuid)
+    .then(() => rollup.writeProjectRollup(emptyProjectRollup.project.id, emptyProjectRollup, user.uuid));
 };
 
 const checkUserSetup = (user) => {
@@ -44,7 +42,7 @@ const checkUserSetup = (user) => {
       if (!projects.length) {
         // create rollups return ID of empty project
         return createInitialData(user)
-          .then(rollups => rollups[0].project.id);
+          .then(rollup => rollup.project.id);
       }
     });
 };

--- a/src/containers/homepage.js
+++ b/src/containers/homepage.js
@@ -45,7 +45,7 @@ export default class HomePage extends Component {
       // NOTE: the nodirect query string prevents redirection
       if (this.props.user && this.props.user.userid && !this.props.location.query.noredirect) {
         // revisit last project
-        this.props.projectOpen(null);
+        this.props.projectOpen(null, true);
         return;
       }
     }
@@ -84,38 +84,6 @@ export default class HomePage extends Component {
         </div>
         <img className="homepage-autodesk" src="/images/homepage/autodesk-logo.png"/>
         <img className="homepage-egf" src="/images/homepage/egf-logo.png"/>
-        <div className="homepage-footer">
-          <div className="homepage-footer-title">New in version 0.1:</div>
-          <div className="homepage-footer-list">
-            <ul>
-              <li><span>&bull;</span>Search and import parts directly from the IGEM and NCBI databases.</li>
-              <li><span>&bull;</span>Specify parts from the Edinburgh Genome Foundry inventory.</li>
-              <li><span>&bull;</span>Import and export GenBank and FASTA files.</li>
-              <li><span>&bull;</span>Create an inventory of your own projects, constructs and parts to reuse.</li>
-              <li><span>&bull;</span>Drag and drop editing.</li>
-            </ul>
-            <ul>
-              <li><span>&bull;</span>Inspect sequence detail.</li>
-              <li><span>&bull;</span>Create nested constructs to manage complexity.</li>
-              <li><span>&bull;</span>Assign SBOL visual symbols and colors.</li>
-              <li><span>&bull;</span>Add titles and descriptions blocks, constructs and projects.</li>
-              <li><span>&bull;</span>Organize constructs into separate projects.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  renderOLD() {
-    return (
-      <div className="homepage">
-        <div className="homepage-image-area">
-          <img className="homepage-background" src="/images/homepage/tiles.jpg"/>
-          <div className="homepage-getstarted" onClick={this.signIn.bind(this)}>Get started</div>
-          <img className="homepage-title" src="/images/homepage/genomedesigner.png"/>
-        </div>
-        <img className="homepage-autodesk" src="/images/homepage/autodesk-logo.png"/>
-        <div className="homepage-egf">Edinburgh Genome Foundry</div>
         <div className="homepage-footer">
           <div className="homepage-footer-title">New in version 0.1:</div>
           <div className="homepage-footer-list">

--- a/src/styles/constructviewercanvas.css
+++ b/src/styles/constructviewercanvas.css
@@ -10,6 +10,7 @@
   text-align: center;
   transition: color var(--timing-fast) ease-in-out, background-color var(--timing-fast) ease-in-out, border-color var(--timing-fast) ease-in-out;
   cursor: default;
+  user-select: none;
 }
 .cvc-hovered {
   border: 1px solid var(--colors-selected);


### PR DESCRIPTION
#### Overview

When create a new user, create the sample projects in sequence, so the empty project has a later saved-by date, so it is always opened first (instead of the template project)

#### Type of change (bug fix, feature, docs, etc.)

Fix

#### Issue

EGFAD-741 #close
EGFAD-791 #close done! #done

#### Breaking Changes

none

#### Other information

slightly slower user creation, since projects created in series rather than parallel.