### PR TITLE
dont allow unselecting all the blocks

### DIFF
--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -535,7 +535,7 @@ export default class Block extends Instance {
   addOptions(...optionIds) {
     invariant(this.isList(), 'must be a list block to add list options');
     invariant(optionIds.every(option => idValidator(option)), 'must pass component IDs');
-    const toAdd = optionIds.reduce((acc, id) => Object.assign(acc, { [id]: false }));
+    const toAdd = optionIds.reduce((acc, id) => Object.assign(acc, { [id]: false }), {});
     const newOptions = Object.assign(cloneDeep(this.options), toAdd);
 
     if (Object.keys(newOptions).length === Object.keys(this.options).length) {

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -511,6 +511,12 @@ export default class Block extends Instance {
     optionIds.forEach(optionId => {
       Object.assign(options, { [optionId]: !this.options[optionId] });
     });
+
+    //disallow removing all the options
+    if (Object.keys(options).filter(id => options[id]).length === 0) {
+      return this;
+    }
+
     return this.mutate('options', options);
   }
 

--- a/test/models/Block.spec.js
+++ b/test/models/Block.spec.js
@@ -144,5 +144,18 @@ describe('Model', () => {
           });
       });
     });
+
+    describe('Lists', () => {
+      it('should not allow unselecting all list options', () => {
+        const options = [0, 1, 2, 3].map(() => new Block());
+        const optionIds = options.map(opt => opt.id);
+        const block = new Block()
+          .setListBlock(true)
+          .addOptions(...optionIds)
+          .toggleOptions(...optionIds);
+
+        expect(block.toggleOptions(...optionIds)).to.equal(block);
+      });
+    });
   });
 });


### PR DESCRIPTION
#### Overview

Don't allow unselecting all list block options

#### Type of change (bug fix, feature, docs, etc.)

feature / bug fix

#### Issue

EGFAD-947

#### Breaking Changes

Can't unselect all the list options

#### Other information

- [x] Adds a test

Ensures that templates always have at least one option active


