### PR TITLE
Update export to Genbank + FASTA

### DIFF
--- a/server/extensions/index.js
+++ b/server/extensions/index.js
@@ -24,6 +24,7 @@ import extensionApiRouter from './apiRouter';
 
 //native extensions
 import csvRouter from './native/csv/index';
+import fastaRouter from './native/fasta/index';
 import genbankRouter from './native/genbank/index';
 
 const router = express.Router(); //eslint-disable-line new-cap
@@ -94,6 +95,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 //handle native extensions which are included statically
 router.use('/api/csv', csvRouter);
+router.use('/api/fasta', fastaRouter);
 router.use('/api/genbank', genbankRouter);
 
 //other /api routes deleted to extension API router

--- a/server/extensions/native/fasta/README.md
+++ b/server/extensions/native/fasta/README.md
@@ -1,0 +1,15 @@
+FASTA Conversion
+
+Basic exporting of project to FASTA files
+
+### API
+
+##### Export specific blocks
+
+Expects `blockIds` to be a comma-separated list of blocks **which have an md5 sequence**
+
+`extensions/api/fasta/export/blocks/:projectId/:blockIds`
+
+##### (TODO) Export a whole project
+
+`extensions/api/fasta/export/project/:projectId`

--- a/server/extensions/native/fasta/index.js
+++ b/server/extensions/native/fasta/index.js
@@ -64,7 +64,10 @@ router.get('/export/blocks/:projectId/:blockIdList', (req, res, next) => {
   rollup.getProjectRollup(projectId)
     .then(roll => {
       const blocks = blockIds.map(blockId => roll.blocks[blockId]);
-      invariant(blocks.every(block => block.sequence.md5), 'some blocks dont have md5');
+      if (!blocks.every(block => block.sequence.md5)) {
+        console.warn('[FASTA] some blocks dont have md5: ' + projectId, blockIds);
+        throw Error('all blocks must have an md5');
+      }
 
       return Promise.all(
         blocks.map(block => persistence.sequenceGet(block.sequence.md5))

--- a/server/extensions/native/fasta/package.json
+++ b/server/extensions/native/fasta/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fasta",
+  "version": "1.0.0",
+  "description": "Converts Constructor Projects into Fasta files",
+  "geneticConstructor": {
+    "router": "index.js"
+  },
+  "author": "Autodesk Inc.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "invariant": "^2.2.1",
+    "lodash": "^4.13.1"
+  }
+}

--- a/server/extensions/native/genbank/index.js
+++ b/server/extensions/native/genbank/index.js
@@ -54,13 +54,56 @@ router.get('/file/:fileId', (req, res, next) => {
 
 /***** EXPORT ******/
 
+router.get('/export/blocks/:projectId/:blockIdList', (req, res, next) => {
+  const { projectId, blockIdList } = req.params;
+  const blockIds = blockIdList.split(',');
+
+  rollup.getProjectRollup(projectId)
+    .then(roll => {
+      const blocks = blockIds.map(blockId => roll.blocks[blockId]);
+      invariant(blocks.every(block => block.sequence.md5), 'some blocks dont have md5');
+
+      const name = (roll.project.metadata.name || roll.project.id) + '.gb';
+
+      const construct = Block.classless({
+        metadata: {
+          name,
+        },
+        components: blocks.map(block => block.id),
+      });
+      const project = Project.classless(Object.assign(roll.project, {
+        components: [construct.id],
+      }));
+
+      const partialRoll = {
+        project,
+        blocks: blocks.reduce((acc, block) => {
+          return Object.assign(acc, {
+            [block.id]: block,
+          });
+        }, {
+          [construct.id]: construct,
+        }),
+      };
+
+      exportConstruct({ roll: partialRoll, constructId: construct.id })
+        .then(fileContents => {
+          res.set({
+            'Content-Disposition': `attachment; filename="${roll.project.id}.fasta"`,
+          });
+          res.send(fileContents);
+        });
+    })
+    .catch(err => {
+      console.log('Error!', err);
+      res.status(500).send(err);
+    });
+});
+
 router.get('/export/:projectId/:constructId?', (req, res, next) => {
   const { projectId, constructId } = req.params;
 
   rollup.getProjectRollup(projectId)
-    .catch(err => {
-      res.status(500).send(err);
-    })
     .then(roll => {
       const name = (roll.project.metadata.name ? roll.project.metadata.name : roll.project.id) + '.gb';
 

--- a/test/extensions/csv.js
+++ b/test/extensions/csv.js
@@ -7,9 +7,6 @@ import { extensionApiPath } from '../../src/middleware/paths';
 import { callExtensionApi } from '../../src/middleware/extensions'
 import rejectingFetch from '../../src/middleware/rejectingFetch';
 
-//noinspection JSUnusedLocalSymbols
-const devServer = require('../../server/server'); // starts the server which will be accessed by methods below
-
 describe('Extensions', () => {
   describe('CSV', () => {
     const fileName = 'simplecsv.csv';

--- a/test/extensions/fasta.js
+++ b/test/extensions/fasta.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import uuid from 'node-uuid';
+import { expect } from 'chai';
+import * as rollup from '../../server/data/rollup';
+import { callExtensionApi } from '../../src/middleware/extensions'
+import { numberBlocksInRollup, createExampleRollup } from '../utils/rollup';
+
+const extensionKey = 'fasta';
+
+describe('Extensions', () => {
+  describe.only('FASTA', () => {
+    const roll = createExampleRollup();
+    const project = roll.project;
+    const projectId = project.id;
+    const leaves = _.values(roll.blocks).filter(block => block.components.length === 0);
+
+    before(() => {
+      return rollup.writeProjectRollup(projectId, roll, '0');
+    });
+
+    it('should be able to export specific blocks', () => {
+      return callExtensionApi(extensionKey, `export/blocks/${projectId}/${leaves[0].id},${leaves[2].id}`)
+        .then(resp => {
+          expect(resp.status).to.equal(200);
+          return resp.text();
+        })
+        .then(fasta => {
+          console.log(fasta);
+        });
+    });
+  });
+});

--- a/test/fixtures/rollup.js
+++ b/test/fixtures/rollup.js
@@ -1,5 +1,4 @@
-
-import invariant from 'invaraint';
+import invariant from 'invariant';
 import { merge } from 'lodash';
 import Block from '../../src/models/Block';
 import Project from '../../src/models/Project';
@@ -48,8 +47,10 @@ export const createExampleProject = () => {
 
   //write everything
   return Promise.all([
-    rollup.writeProjectRollup(roll.project.id, roll, 0),
+    rollup.writeProjectRollup(roll.project.id, roll, '0'),
     ...Object.keys(sequenceRoll.sequences).map(seqMd5 => persistence.sequenceWrite(seqMd5, sequenceRoll.sequences[seqMd5])),
   ])
     .then(() => roll);
 };
+
+export default createExampleProject;

--- a/test/fixtures/rollup.js
+++ b/test/fixtures/rollup.js
@@ -1,0 +1,55 @@
+
+import invariant from 'invaraint';
+import { merge } from 'lodash';
+import Block from '../../src/models/Block';
+import Project from '../../src/models/Project';
+import * as rollup from '../../server/data/rollup';
+import * as persistence from '../../server/data/persistence';
+import { createExampleRollup, createSequencedRollup } from '../utils/rollup';
+
+/**
+ * only for testing... all created with test user account
+ * create a project with some example constructs
+ *
+ * 0 - hierarchy, no sequence, no lists
+ *
+ *     project
+ *       |
+ *       P
+ *  /----|-----\
+ *  A     B    F
+ * /-\   |
+ * C  D  E
+ *
+ * 1 - flat, all blocks have sequence
+ *
+ * project
+ * |
+ * A
+ * |
+ * B*-C*-D*-E*-F*-G*
+ *
+ * 2 - template with lists (e.g. EGF) TODO!!!!
+ *
+ */
+export const createExampleProject = () => {
+  invariant(process.env.NODE_ENV === 'test', 'can only be used in testing environment');
+
+  //handle construct 0, assign rest onto this
+  const roll = createExampleRollup();
+
+  //construct 1
+  const sequenceRoll = createSequencedRollup();
+  roll.project.components.push(...sequenceRoll.project.components);
+  Object.assign(roll.blocks, sequenceRoll.blocks);
+
+  //construct 2
+  //todo
+
+  //write everything
+  return Promise.all([
+    rollup.writeProjectRollup(roll.project.id, roll, 0),
+    ...Object.keys(sequenceRoll.sequences).map(seqMd5 => persistence.sequenceWrite(seqMd5, sequenceRoll.sequences[seqMd5])),
+  ])
+    .then(() => roll);
+};

--- a/test/utils/rollup.js
+++ b/test/utils/rollup.js
@@ -62,8 +62,8 @@ export const createSequencedRollup = () => {
   const sequences = range(numSeqs).map(() => generateRandomSequence());
   const sequenceMd5s = sequences.map(seq => md5(seq));
   const sequenceMap = sequenceMd5s.reduce((acc, seqMd5, index) => {
-    return Object.assign(acc, { [seqMd5] : sequences[index] });
-  });
+    return Object.assign(acc, { [seqMd5]: sequences[index] });
+  }, {});
 
   const blocks = range(numSeqs).map((index) => Block.classless({
     sequence: {
@@ -72,14 +72,14 @@ export const createSequencedRollup = () => {
   }));
 
   const construct = Block.classless({
-    components: blocks.map(block => block.id)
+    components: blocks.map(block => block.id),
   });
 
   const project = Project.classless({
     components: [construct.id],
   });
 
-  const roll = rollupFromArray(project, ...blocks);
+  const roll = rollupFromArray(project, ...blocks, construct);
   Object.assign(roll, { sequences: sequenceMap });
   return roll;
 };

--- a/test/utils/rollup.js
+++ b/test/utils/rollup.js
@@ -1,6 +1,9 @@
+import md5 from 'md5';
+import { range } from 'lodash';
 import Project from '../../src/models/Project';
 import Block from '../../src/models/Block';
 import rollupFromArray from '../../src/utils/rollup/rollupFromArray';
+import { generateRandomSequence } from '../utils/sequence';
 
 export const numberBlocksInRollup = 7;
 
@@ -43,5 +46,40 @@ export const createExampleRollup = () => {
   blocks.forEach(block => Object.assign(block, { projectId: project.id }));
 
   const roll = rollupFromArray(project, ...blocks);
+  return roll;
+};
+
+//note - slightly abnormal signature (since for tests), returns sequences on the rollup as well
+/*
+ * project
+ * |
+ * A
+ * |
+ * B*-C*-D*-E*-F*-G*
+ */
+export const createSequencedRollup = () => {
+  const numSeqs = numberBlocksInRollup - 1;
+  const sequences = range(numSeqs).map(() => generateRandomSequence());
+  const sequenceMd5s = sequences.map(seq => md5(seq));
+  const sequenceMap = sequenceMd5s.reduce((acc, seqMd5, index) => {
+    return Object.assign(acc, { [seqMd5] : sequences[index] });
+  });
+
+  const blocks = range(numSeqs).map((index) => Block.classless({
+    sequence: {
+      md5: sequenceMd5s[index],
+    },
+  }));
+
+  const construct = Block.classless({
+    components: blocks.map(block => block.id)
+  });
+
+  const project = Project.classless({
+    components: [construct.id],
+  });
+
+  const roll = rollupFromArray(project, ...blocks);
+  Object.assign(roll, { sequences: sequenceMap });
   return roll;
 };

--- a/test/utils/sequence.js
+++ b/test/utils/sequence.js
@@ -1,0 +1,10 @@
+const bases = 'ACGT'.split('');
+const numBases = bases.length;
+
+export const generateRandomSequence = (length = 100) => {
+  let sequence = '';
+  for (let i = 0; i < length; i++) {
+    sequence = sequence + bases[Math.floor(Math.random() * numBases)];
+  }
+  return sequence;
+};


### PR DESCRIPTION
#### Overview

Add router to handle export to FASTA and one to Genbank for parity. Allows exporting of specific blocks (which must have a sequence) in a given project, e.g. for the order modal

Specific route in format:

`extensions/api/fasta/export/blocks/:projectId/:blockIds`
`extensions/api/genbank/export/blocks/:projectId/:blockIds`

These routes should be well-adapted to supporting a download in the order modal

#### Type of change (bug fix, feature, docs, etc.)

Feature

#### Issue

EGFAD-931

#### Breaking Changes

none

#### Requirements

- [x] Adds a test (for features + fixes)
- [x] Docs updated (for features + fixes)

#### Other information


