### PR TITLE
elide very long inventory item names

### DIFF
--- a/src/styles/InventoryListGroup.css
+++ b/src/styles/InventoryListGroup.css
@@ -24,6 +24,9 @@
 
   &-title {
     cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &-contents {


### PR DESCRIPTION
#### Overview

Elide long inventory names when groups (e.g. constructs), to match inventory items

#### Type of change (bug fix, feature, docs, etc.)

UI

#### Issue

EGFAD-961



