### PR TITLE
ignore npm packages and test ouput in root dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,9 @@
 .idea
 node_modules/
 test-deprecated/
+storage/test/*
+genome-designer-*.tgz
+genetic-constructor-*.tgz
+jenkins-docker-*.tgz
+report.xml
+eslint.xml

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ screenshots/
 report.xml
 eslint.xml
 VERSION
+build-manifest.txt


### PR DESCRIPTION
#### Overview

Ignore more files when building Docker Images so that Docker images remain as small as possible.

#### Type of change (bug fix, feature, docs, UI, etc.)

bug fix

#### Breaking Changes

none

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue


