### PR TITLE
change Docker image refs from genome-designer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Docker Repository on Quay](https://quay.io/repository/autodesk_bionano/genomedesigner_genome-designer/status "Docker Repository on Quay")](https://quay.io/repository/autodesk_bionano/genomedesigner_genome-designer)
+[![Docker Repository on Quay](https://quay.io/repository/autodesk_bionano/gctor_webapp/status "Docker Repository on Quay")](https://quay.io/repository/autodesk_bionano/genomedesigner_genome-designer)
 
 # Genetic Constructor
 

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -1,4 +1,4 @@
-genome-designer:
+webapp:
   build: .
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-jenkins.yml
+++ b/docker-compose-jenkins.yml
@@ -1,7 +1,7 @@
 test:
   extends:
     file: docker-compose-common.yml
-    service: genome-designer
+    service: webapp
   build: .
   command:
     npm run test-jenkins

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,7 +1,7 @@
-genome-designer:
+webapp:
   extends:
     file: docker-compose-quickstart.yml
-    service: genome-designer
-  image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
+    service: webapp
+  image: quay.io/autodesk_bionano/gctor_webapp${BNR_ENV_TAG}
   environment:
     HOST_URL: https://geneticconstructor.bionano.autodesk.com

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -1,8 +1,8 @@
-genome-designer:
+webapp:
   extends:
     file: docker-compose.yml
-    service: genome-designer
-  image: quay.io/autodesk_bionano/genomedesigner_genome-designer${BNR_ENV_TAG}
+    service: webapp
+  image: quay.io/autodesk_bionano/gctor_webapp${BNR_ENV_TAG}
   volumes:
     - /storage/genome-designer/projects:/projects
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-genome-designer:
+webapp:
   extends:
     file: docker-compose-common.yml
-    service: genome-designer
+    service: webapp
   build: .
   command:
     npm run start-instance

--- a/jenkins-config.yml
+++ b/jenkins-config.yml
@@ -1,4 +1,4 @@
-service-name: genomedesigner
+service-name: gctor
 # NOTE override this value in the Jenkins job as it varies by environment
 environment: local
 


### PR DESCRIPTION
#### Overview

Changes references to `genome-designer` as docker images and docker compose targets to `gctor` and `webapp`. Mostly this removes redundancy in the docker image names created with docker-compose, but it also shortens names. This change can be merged in before or after the GitHub repository name is changed.

Once this change is merged in, Jenkins will build and push Docker Images for the Genetic Constructor Web Application to: https://quay.io/repository/autodesk_bionano/gctor_webapp

#### Type of change (bug fix, feature, docs, UI, etc.)

Configuration changes to all Docker compose files and the Jenkins configuration file. 

#### Breaking Changes

Anyone dependent on the old quay.io repository will no longer get updated builds.

#### Requirements

- [ ] Adds a test (for features + fixes)
- [X] Docs updated (for features + fixes)

#### Other information



#### Issue


