### PR TITLE
identify users on homepage, or when sign in/up occurs to heap analytics

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -42,8 +42,8 @@ const _userSetUser = (user) => ({
  * identify user to heap analytics
  */
 const identifyUser = (email) => {
-  if (heap && heap.identify) {
-    heap.identify(email);
+  if (window && window.heap && window.heap.identify) {
+    window.heap.identify(email);
   }
 }
 

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -38,12 +38,22 @@ const _userSetUser = (user) => ({
   user,
 });
 
+/**
+ * identify user to heap analytics
+ */
+const identifyUser = (userid) => {
+  if (heap && heap.identify) {
+    heap.identify(userid);
+  }
+}
+
 //Promise
 export const userLogin = (email, password) => {
   return (dispatch, getState) => {
     return login(email, password)
       .then(user => {
         const mappedUser = mapUserFromServer(user);
+        identifyUser(mappedUser.userid);
         const setUserPayload = _userSetUser(mappedUser);
         dispatch(setUserPayload);
         return mappedUser;
@@ -70,6 +80,7 @@ export const userRegister = (user) => {
     return register(user)
       .then(user => {
         const mappedUser = mapUserFromServer(user);
+        identifyUser(mappedUser.userid);
         const setUserPayload = _userSetUser(mappedUser);
         dispatch(setUserPayload);
         return user;

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -41,9 +41,9 @@ const _userSetUser = (user) => ({
 /**
  * identify user to heap analytics
  */
-const identifyUser = (userid) => {
+const identifyUser = (email) => {
   if (heap && heap.identify) {
-    heap.identify(userid);
+    heap.identify(email);
   }
 }
 
@@ -53,7 +53,7 @@ export const userLogin = (email, password) => {
     return login(email, password)
       .then(user => {
         const mappedUser = mapUserFromServer(user);
-        identifyUser(mappedUser.userid);
+        identifyUser(mappedUser.email);
         const setUserPayload = _userSetUser(mappedUser);
         dispatch(setUserPayload);
         return mappedUser;
@@ -80,7 +80,7 @@ export const userRegister = (user) => {
     return register(user)
       .then(user => {
         const mappedUser = mapUserFromServer(user);
-        identifyUser(mappedUser.userid);
+        identifyUser(mappedUser.email);
         const setUserPayload = _userSetUser(mappedUser);
         dispatch(setUserPayload);
         return user;
@@ -93,6 +93,7 @@ export const userUpdate = (user) => {
     return updateAccount(user)
       .then(user => {
         const mappedUser = mapUserFromServer(user);
+        identifyUser(mappedUser.email);
         const setUserPayload = _userSetUser(mappedUser);
         dispatch(setUserPayload);
         return user;

--- a/src/containers/GlobalNav.js
+++ b/src/containers/GlobalNav.js
@@ -202,6 +202,12 @@ class GlobalNav extends Component {
     });
   }
 
+  componentDidMount() {
+    // if we have a user then identify them to heap
+    if (heap && heap.identify && flashedUser && flashedUser.email) {
+      heap.identify(flashedUser.email);
+    }
+  }
   /**
    * unsink all keyboard events on unmount
    */

--- a/src/containers/homepage.js
+++ b/src/containers/homepage.js
@@ -45,6 +45,12 @@ export default class HomePage extends Component {
   // this route can result from path like 'homepage/signin', 'homepage', 'homepage/register' etc.
   // If the final path is the name of an authorization form we will show it
   componentDidMount() {
+
+    // if we have a user then identify them to heap
+    if (heap && heap.identify && this.props.user && this.props.userid) {
+      heap.identify(this.props.userid);
+    }
+        
     const authForm = this.props.params.comp;
     if (['signin', 'signup', 'account', 'reset', 'forgot'].indexOf(authForm) >= 0) {
       this.props.uiShowAuthenticationForm(authForm);

--- a/src/containers/homepage.js
+++ b/src/containers/homepage.js
@@ -46,11 +46,6 @@ export default class HomePage extends Component {
   // If the final path is the name of an authorization form we will show it
   componentDidMount() {
 
-    // if we have a user then identify them to heap
-    if (heap && heap.identify && this.props.user && this.props.userid) {
-      heap.identify(this.props.userid);
-    }
-        
     const authForm = this.props.params.comp;
     if (['signin', 'signup', 'account', 'reset', 'forgot'].indexOf(authForm) >= 0) {
       this.props.uiShowAuthenticationForm(authForm);


### PR DESCRIPTION
#### Overview

When present, use the heap analytics api to associated users with the session. Occurs on homepage and in sign in/ sign up middleware

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue


