### PR TITLE
dont deleted all extension - just those not in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-client": "babel-node tools/run bundle",
     "jsdoc": "jsdoc -c docs/jsdoc/jsdoc.conf.json --package package.json --readme docs/jsdoc/jsdoc.md",
     "postinstall": "npm run install-extensions && npm run selenium && babel-node tools/run install-dependencies",
-    "install-extensions": "cd server/extensions && rm -rf node_modules && npm install --only=prod --no-bin-link --no-optional",
+    "install-extensions": "cd server/extensions && node ./pruneNodeModules.js && npm install --only=prod --no-bin-link --no-optional",
     "check": "npm run lint && npm run test",
     "lint": "make lint",
     "lint-jscs": "jscs src server",

--- a/server/extensions/pruneNodeModules.js
+++ b/server/extensions/pruneNodeModules.js
@@ -19,14 +19,29 @@ const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
 
-const pkg = require(path.resolve(__dirname, 'package.json'));
-const deps = pkg.dependencies;
-const dirContents = fs.readdirSync(path.resolve(__dirname, 'node_modules'));
+const nodeModulePath = path.resolve(__dirname, 'node_modules');
 
-dirContents.forEach(dir => {
-  if (!deps[dir]) {
-    rimraf(path.resolve(__dirname, 'node_modules', dir), function callback() {
-      console.log('deleted extension (not listed in package.json): ' + dir);
-    });
+fs.stat(nodeModulePath, function checkDirExists(err, stat) {
+  if (err) {
+    if (err.code === 'ENOENT') {
+      return;
+    }
+
+    console.error('error checking for directory server/extensions/node_modules');
+    console.error(err);
+    throw err;
   }
+
+  const pkg = require(path.resolve(__dirname, 'package.json'));
+  const deps = pkg.dependencies;
+  const dirContents = fs.readdirSync(nodeModulePath);
+
+  dirContents.forEach(function checkDir(dir) {
+    if (!deps[dir]) {
+      rimraf(path.resolve(nodeModulePath, dir), function callback() {
+        console.log('deleted extension (not listed in package.json): ' + dir);
+      });
+    }
+  });
 });
+

--- a/server/extensions/pruneNodeModules.js
+++ b/server/extensions/pruneNodeModules.js
@@ -1,0 +1,32 @@
+/*
+ Copyright 2016 Autodesk,Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+//run this script with node to clear our extensions which are not listed in server/extensions/package.json
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const pkg = require(path.resolve(__dirname, 'package.json'));
+const deps = pkg.dependencies;
+const dirContents = fs.readdirSync(path.resolve(__dirname, 'node_modules'));
+
+dirContents.forEach(dir => {
+  if (!deps[dir]) {
+    rimraf(path.resolve(__dirname, 'node_modules', dir), function callback() {
+      console.log('deleted extension (not listed in package.json): ' + dir);
+    });
+  }
+});


### PR DESCRIPTION
#### Overview

adds node script to prune node modules of extensions only to those which are not listed in package.json, not to delete them all

#### Type of change (bug fix, feature, docs, UI, etc.)

feature

#### Breaking Changes

extensions not forcibly cleared every start. should not have any effect.

#### Other information

supports GSL, which has a postinstall requirement to include the compiled GSL source