### PR TITLE
Selenium Standalone -> 5.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "readline-sync": "^1.4.4",
     "redbox-react": "^1.3.0",
     "redux-devtools": "^3.3.1",
-    "selenium-standalone": "4.9.1",
+    "selenium-standalone": "5.7.2",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
     "supertest": "^1.1.0",


### PR DESCRIPTION
#### Overview

update selenium standalone package

#### Type of change (bug fix, feature, docs, UI, etc.)

test dependency

#### Other information

to support chrome driver 2.24

does not affect build. affects end to end tests


