### PR TITLE
Modified the Dockerfile for GSL Jenkins build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN yes | pip install biopython
 
 RUN pip install awscli
 
-#install fsharp (needed by gslEditor extension if it exists)
-RUN if [ -d ./extensions/gslEditor/ ]; then ./extensions/gslEditor/tools/install-fsharp.sh ; fi
-
 EXPOSE 3000
 ENV PORT=3000
 
@@ -38,6 +35,10 @@ ADD package.json /app/package.json
 RUN npm update -g npm && npm install
 
 ADD . /app
+
+#install fsharp (needed by gslEditor extension if it exists)
+RUN if [ -d ./extensions/gslEditor/ ]; then ./extensions/gslEditor/tools/install-fsharp.sh ; fi
+
 #install extensions, continue even if errors
 RUN npm run install-extensions || true
 


### PR DESCRIPTION
#### Overview

Install fsharp after the app is added to Dockerfile.

#### Type of change (bug fix, feature, docs, UI, etc.)

fix

#### Breaking Changes

None

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

Seeing this in Jenkins: 

Reading package lists...
running sudo apt-get install mono-devel -yf
{ [Error: Command failed: /bin/sh -c sudo apt-get install mono-devel -yf
E: Unable to correct problems, you have held broken packages.
]
  killed: false,
  code: 100,
  signal: null,
  cmd: '/bin/sh -c sudo apt-get install mono-devel -yf' } 
