### PR TITLE
GSL extension - Mono installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN yes | pip install biopython
 
 RUN pip install awscli
 
-#install fsharp (needed by gslEditor extension if it exists)
-RUN if [ -d ./extensions/gslEditor/ ]; then ./extensions/gslEditor/tools/install-fsharp.sh ; fi
-
 EXPOSE 3000
 ENV PORT=3000
 
@@ -38,6 +35,10 @@ ADD package.json /app/package.json
 RUN npm update -g npm && npm install
 
 ADD . /app
+
+#install fsharp (needed by gslEditor extension if it exists)
+RUN if [ -d ./extensions/gslEditor/ ]; then ./extensions/gslEditor/tools/install-fsharp.sh ; fi
+
 #install extensions, continue even if errors
 RUN npm run install-extensions || true
 

--- a/extensions/gslEditor/tools/install-fsharp.js
+++ b/extensions/gslEditor/tools/install-fsharp.js
@@ -20,9 +20,9 @@ async function installFSharp() {
       commandExists('mono', async function(err, exists) {
         if (err || !exists) {
           await promisedExec('sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y', {}, { forceOutput: true});
-          await promisedExec('sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', {}, { forceOutput: true});
-          await promisedExec('echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list', {}, { forceOutput: true});
-          await promisedExec('echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list', {}, { forceOutput: true});
+          //await promisedExec('sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', {}, { forceOutput: true});
+          //await promisedExec('echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list', {}, { forceOutput: true});
+          //await promisedExec('echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list', {}, { forceOutput: true});
           await promisedExec('sudo apt-get update -y', {}, { forceOutput: true});
           await promisedExec('sudo apt-get install mono-devel -yf', {}, { forceOutput: true});
           await promisedExec('sudo apt-get install ca-certificates-mono -yf', {}, { forceOutput: true});

--- a/extensions/gslEditor/tools/install-fsharp.sh
+++ b/extensions/gslEditor/tools/install-fsharp.sh
@@ -16,9 +16,9 @@ if [[ ("$OSTYPE" == "linux-gnu") ||  ("$OSTYPE" == "cygwin") ]]; then
 
     set -x
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-    echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
+    #sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    #echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+    #echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 
     sudo apt-get update -y
     sudo apt-get install mono-devel -yf


### PR DESCRIPTION
#### Overview

Fixes the issue of missing mono libraries for GSL execution.

#### Type of change (bug fix, feature, docs, UI, etc.)

Fix

#### Breaking Changes

None

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information

#### Issue
This fixes the fact that /usr/lib/mono/4.5/mscorlib.dll was missing in the mono installation on the server. 
http://askubuntu.com/questions/600972/why-cant-i-install-mono-complete


